### PR TITLE
Add application bootstrap and admin demo reset functionality

### DIFF
--- a/src/integrationTest/java/io/github/ajmiller611/usermanagement/service/UserServiceIntegrationTests.java
+++ b/src/integrationTest/java/io/github/ajmiller611/usermanagement/service/UserServiceIntegrationTests.java
@@ -9,7 +9,6 @@ import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.dto.UserUpdateRequestDto;
 import io.github.ajmiller611.usermanagement.exception.UserAlreadyExistsException;
 import io.github.ajmiller611.usermanagement.exception.UserNotFoundException;
-import io.github.ajmiller611.usermanagement.model.Role;
 import io.github.ajmiller611.usermanagement.model.User;
 import io.github.ajmiller611.usermanagement.repository.RoleRepository;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
@@ -74,12 +73,9 @@ class UserServiceIntegrationTests {
   @Autowired private PasswordEncoder passwordEncoder;
   @Mock private Clock clock;
 
-  Role userRole;
-
   /** Verify {@code createAndSaveUser()} saves user with encoded password and correct roles. */
   @Test
   void givenValidUserRequestDtoWhenCreateAndSaveUserThenUserSavedProperly() {
-    initializeUserRole();
     UserRequestDto userRequestDto = new UserRequestDto(
         "testUser",
         "password",
@@ -90,7 +86,7 @@ class UserServiceIntegrationTests {
     User user = userRepository.findByUsername("testUser").orElseThrow();
 
     assertNotNull(user, "The user should not be null after saving.");
-    assertEquals(1L, user.getUserId(), "The user ID should be 1.");
+    assertNotNull(user.getUserId(), "The user ID should not be null.");
     assertEquals(userRequestDto.getUsername(), user.getUsername(),
         "The username should match the provided username.");
     assertTrue(passwordEncoder.matches(userRequestDto.getPassword(), user.getPassword()),
@@ -99,7 +95,7 @@ class UserServiceIntegrationTests {
         "The email should match the provided email.");
     assertTrue(user.getCreatedAt().isBefore(LocalDateTime.now()),
         "The creation date should be before the current date.");
-    assertTrue(user.getAuthorities().contains(userRole),
+    assertTrue(user.getAuthorities().contains(roleRepository.findByAuthority("USER").get()),
         "The user should have the 'USER' role assigned.");
   }
 
@@ -110,7 +106,6 @@ class UserServiceIntegrationTests {
    */
   @Test
   void givenExistingUserWhenCreateAndSaveUserThenThrowUserAlreadyExistsException() {
-    initializeUserRole();
     String existingUsername = "existingUser";
     User existingUser = new User(
         2L,
@@ -118,7 +113,7 @@ class UserServiceIntegrationTests {
         "password",
         "existing@example.com",
         LocalDateTime.now(),
-        Set.of(userRole)
+        Set.of(roleRepository.findByAuthority("USER").get())
     );
     userRepository.save(existingUser);
 
@@ -133,7 +128,7 @@ class UserServiceIntegrationTests {
         "Expected createAndSaveUser to throw an exception for an existing user");
 
     Long userCountAfter = userRepository.count();
-    assertEquals(1, userCountAfter,
+    assertEquals(2, userCountAfter,
         "The number of users in the database should not have changed.");
   }
 
@@ -178,13 +173,5 @@ class UserServiceIntegrationTests {
     assertThrows(UserNotFoundException.class,
         () -> userService.deleteUser(nonExistentId),
         "Expected deleteUser to throw a UserNotFoundException for a nonexistent user");
-  }
-
-  /**
-   * Initializes the 'USER' role by saving it to the database. This utility method optimizes
-   * test runtime by limiting role creation to only test cases that require the 'USER' role.
-   */
-  private void initializeUserRole() {
-    userRole = roleRepository.save(new Role("USER"));
   }
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/UserManagementApplication.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/UserManagementApplication.java
@@ -1,38 +1,20 @@
 package io.github.ajmiller611.usermanagement;
 
-import io.github.ajmiller611.usermanagement.model.Role;
-import io.github.ajmiller611.usermanagement.model.User;
-import io.github.ajmiller611.usermanagement.repository.RoleRepository;
-import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
-import org.springframework.core.env.Environment;
-import org.springframework.security.crypto.password.PasswordEncoder;
+
 
 /**
  * Entry point for the User Management application.
  *
  * <p>This class is the main class for the Spring Boot application.
- * It initializes the Spring application context and launches the application.
- * It creates default roles(e.g. "ADMIN", "USER") and an Admin user.
+ * It bootstraps the Spring Boot application and defines startup behavior.
  * </p>
  */
 @RequiredArgsConstructor
 @SpringBootApplication
 public class UserManagementApplication {
-
-  private final Environment env;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   /**
    * Main method that serves as the entry point for the application.
@@ -41,65 +23,5 @@ public class UserManagementApplication {
    */
   public static void main(String[] args) {
     SpringApplication.run(UserManagementApplication.class, args);
-  }
-
-  /**
-   * CommandLineRunner bean returns a lambda expression to execute instructions
-   * for initializing the database with default roles and a user with "ADMIN" role.
-   *
-   * <p>This bean is executed when the application starts. It checks if the "ADMIN" role already
-   * exists in the RoleRepository. If not, it creates the "ADMIN" and "USER" roles, then creates
-   * a default admin user with the "ADMIN" role, and saves both the roles and the user to the
-   * database.
-   * </p>
-   *
-   * @param roleRepository The repository used to interact with the roles in the database.
-   * @param userRepository The repository used to interact with the users in the database.
-   * @param passwordEncoder The password encoder used to encode the user's password.
-   * @return A lambda expression representing the execution of instructions to initialize
-   *         the database with roles and an admin user if they do not already exist.
-   */
-  @Bean
-  @Profile("dev")
-  CommandLineRunner run(
-      RoleRepository roleRepository,
-      UserRepository userRepository,
-      PasswordEncoder passwordEncoder,
-      Clock clock
-  ) {
-
-    return args -> {
-      if (roleRepository.findByAuthority("ADMIN").isPresent()) {
-        return;
-      }
-
-      // Create an Admin role and save it to the database.
-      Role adminRole = roleRepository.save(new Role("ADMIN"));
-      logger.info("Role created: {}", adminRole);
-      Role userRole = roleRepository.save(new Role("USER"));
-      logger.info("Role created: {}", userRole);
-
-      Set<Role> roles = new HashSet<>();
-      roles.add(adminRole);
-      roles.add(userRole);
-
-      String passwordFromEnv = env.getProperty("ADMIN_PASSWORD");
-
-      if (passwordFromEnv == null || passwordFromEnv.isBlank()) {
-        throw new IllegalStateException("ADMIN_PASSWORD is not set");
-      }
-
-      // Create a user with admin role.
-      User admin = new User(
-          1L,
-          "admin",
-          passwordEncoder.encode(passwordFromEnv),
-          "admin@example.com",
-          LocalDateTime.now(clock),
-          roles
-      );
-      userRepository.save(admin);
-      logger.info("Admin User created: {}", admin);
-    };
   }
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/config/BootstrapRunnerConfig.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/config/BootstrapRunnerConfig.java
@@ -1,0 +1,33 @@
+package io.github.ajmiller611.usermanagement.config;
+
+import io.github.ajmiller611.usermanagement.service.BootstrapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class responsible for application startup initialization.
+ *
+ * <p>Defines a {@link CommandLineRunner} bean that runs when the application starts
+ * and delegates initialization logic to {@link BootstrapService}.</p>
+ *
+ * <p>This setup ensures required roles and the default admin user exist
+ * without placing startup logic directly in the main application class.</p>
+ */
+@Configuration
+@RequiredArgsConstructor
+public class BootstrapRunnerConfig {
+
+  private final BootstrapService bootstrapService;
+
+  /**
+   * Executes application bootstrap logic at startup.
+   *
+   * @return a {@link CommandLineRunner} that invokes initialization logic
+   */
+  @Bean
+  CommandLineRunner initialize() {
+    return args -> bootstrapService.initialize();
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/config/SecurityConfig.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/config/SecurityConfig.java
@@ -52,6 +52,8 @@ public class SecurityConfig {
   private final JwtAuthenticationFilter jwtAuthFilter;
   private final JwtAuthenticationConverter jwtAuthenticationConverter;
 
+  private static final String ADMIN = "ADMIN";
+
   /**
    * Creates a {@link PasswordEncoder} bean for securely encoding passwords.
    *
@@ -119,10 +121,11 @@ public class SecurityConfig {
             .configurationSource(apiCorsConfigurationSource()))
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(auth -> {
+          auth.requestMatchers("/admin/**").hasRole(ADMIN);
           auth.requestMatchers("/auth/**").permitAll();
           auth.requestMatchers("/auth/me").authenticated();
-          auth.requestMatchers(HttpMethod.GET, "/users/**").hasAnyRole("ADMIN", "USER");
-          auth.requestMatchers("/users/**").hasRole("ADMIN");
+          auth.requestMatchers(HttpMethod.GET, "/users/**").hasAnyRole(ADMIN, "USER");
+          auth.requestMatchers("/users/**").hasRole(ADMIN);
           auth.anyRequest().authenticated();
         });
     http

--- a/src/main/java/io/github/ajmiller611/usermanagement/controller/DemoResetController.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/controller/DemoResetController.java
@@ -1,0 +1,43 @@
+package io.github.ajmiller611.usermanagement.controller;
+
+import io.github.ajmiller611.usermanagement.service.DemoResetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller responsible for managing demo data operations.
+ *
+ * <p>This controller provides administrative endpoints for resetting
+ * demo data within the system. It is intended for use in development
+ * and demonstration environments only.</p>
+ *
+ * <p>Access to all endpoints in this controller is restricted to users
+ * with the ADMIN role.</p>
+ */
+@RestController
+@RequestMapping("/admin/demo")
+@RequiredArgsConstructor
+public class DemoResetController {
+
+  private final DemoResetService demoResetService;
+
+  /**
+   * Resets the application's demo data to its initial state.
+   *
+   * <p>This operation clears and reinitializes demo-related data
+   * by delegating to the {@link DemoResetService}.</p>
+   *
+   * @return a {@link ResponseEntity} containing a success message
+   *         confirming the demo data has been reset
+   */
+  @PostMapping("/reset")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<String> resetDemo() {
+    demoResetService.resetDemoData();
+    return ResponseEntity.ok("Demo data reset successfully.");
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/repository/UserRepository.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/repository/UserRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -43,4 +44,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
    */
   @Query("SELECT u FROM User u WHERE NOT :role MEMBER OF u.authorities")
   Page<User> findAllWithoutRole(Pageable pageable, Role role);
+
+  /**
+   * Deletes all records from the user_role_junction table.
+   *
+   * <p>This operation removes all existing user-role associations from the many-to-many join table
+   * between users and roles.
+   *
+   * <p>This method is intended for use in resetting the demo data to an initial state.
+   *
+   * <p>The query is marked as modifying because it performs a write operation and must be executed
+   *  within a transactional context.
+   */
+  @Modifying
+  @Query(value = "DELETE FROM user_role_junction", nativeQuery = true)
+  void deleteAllUserRoleMappings();
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/service/BootstrapService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/service/BootstrapService.java
@@ -1,0 +1,103 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import io.github.ajmiller611.usermanagement.model.Role;
+import io.github.ajmiller611.usermanagement.model.User;
+import io.github.ajmiller611.usermanagement.repository.RoleRepository;
+import io.github.ajmiller611.usermanagement.repository.UserRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service responsible for bootstrapping the system with required baseline data.
+ *
+ * <p>This ensures the application has the minimum required data to start and operate,
+ * including required roles and a default administrator account.</p>
+ */
+@Service
+@RequiredArgsConstructor
+public class BootstrapService {
+
+  private final Environment env;
+  private final RoleRepository roleRepository;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final Clock clock;
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  private static final String ADMIN = "ADMIN";
+  private static final String USER = "USER";
+
+  /**
+   * Initializes the system by ensuring required roles and an administrator account exist.
+   *
+   * <p>This method should be called during application startup to guarantee that the system
+   * is in a valid and usable state. It enforces the correct order of operations by ensuring
+   * roles are created before attempting to create the admin user.</p>
+   */
+  public void initialize() {
+    ensureRolesExist();
+    ensureAdminExists();
+  }
+
+  /**
+   * Ensures that the required roles ("ADMIN" and "USER") exist in the system.
+   * Creates them if they are missing.
+   */
+  public void ensureRolesExist() {
+    if (roleRepository.findByAuthority(ADMIN).isEmpty()) {
+      Role adminRole = roleRepository.save(new Role(ADMIN));
+      logger.info("Role created: {}", adminRole);
+    }
+
+    if (roleRepository.findByAuthority(USER).isEmpty()) {
+      Role userRole = roleRepository.save(new Role(USER));
+      logger.info("Role created: {}", userRole);
+    }
+  }
+
+  /**
+   * Ensures that a default administrator user exists in the system.
+   *
+   * <p>If a user with the username "admin" does not exist, a new admin user is created
+   * with both "ADMIN" and "USER" roles. If the user already exists, no action is taken.</p>
+   *
+   * @throws IllegalStateException if required roles are not found
+   * @throws IllegalArgumentException if the ADMIN_PASSWORD environment variable is not set
+   */
+  public void ensureAdminExists() {
+    if (userRepository.findByUsername("admin").isPresent()) {
+      return;
+    }
+
+    Role adminRole = roleRepository.findByAuthority(ADMIN)
+        .orElseThrow(() -> new IllegalStateException("ADMIN role not found"));
+    Role userRole = roleRepository.findByAuthority(USER)
+        .orElseThrow(() -> new IllegalStateException("USER role not found"));
+
+    Set<Role> roles = Set.of(adminRole, userRole);
+
+    String passwordFromEnv = env.getProperty("ADMIN_PASSWORD");
+    if (passwordFromEnv == null || passwordFromEnv.isBlank()) {
+      throw new IllegalArgumentException("ADMIN_PASSWORD is not set");
+    }
+
+    User admin = new User(
+        null,
+        "admin",
+        passwordEncoder.encode(passwordFromEnv),
+        "admin@example.com",
+        LocalDateTime.now(clock),
+        roles
+    );
+
+    userRepository.save(admin);
+    logger.info("Admin created: {}", admin);
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/service/DemoResetService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/service/DemoResetService.java
@@ -1,0 +1,70 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import io.github.ajmiller611.usermanagement.model.Role;
+import io.github.ajmiller611.usermanagement.model.User;
+import io.github.ajmiller611.usermanagement.repository.RoleRepository;
+import io.github.ajmiller611.usermanagement.repository.UserRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service responsible for resetting the application to a predefined demo state.
+ *
+ * <p>This includes removing existing user data, restoring required system users,
+ * and recreating sample users for demonstration and testing purposes.</p>
+ */
+@Service
+@RequiredArgsConstructor
+public class DemoResetService {
+
+  private final UserRepository userRepository;
+  private final RoleRepository roleRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final Clock clock;
+  private final BootstrapService bootstrapService;
+
+  /**
+   * Resets the application to a demo state.
+   *
+   * <p>This method clears existing user data and user-role mappings,
+   * then re-creates the required roles, the default admin user,
+   * and a small set of demo users for testing and development.</p>
+   *
+   * <p>The operation is transactional to ensure the database is
+   * properly updated as a single unit of work.</p>
+   */
+  @Transactional
+  public void resetDemoData() {
+
+    // Remove dependent data first
+    userRepository.deleteAllUserRoleMappings();
+    userRepository.deleteAll();
+
+    bootstrapService.ensureRolesExist();
+    bootstrapService.ensureAdminExists();
+
+    createDemoUser("testUser1", "testPassword1");
+    createDemoUser("testUser2", "testPassword2");
+  }
+
+  private void createDemoUser(String username, String password) {
+    Role userRole = roleRepository.findByAuthority("USER")
+        .orElseThrow(() -> new IllegalStateException("USER role not found."));
+
+    User user = new User(
+        null,
+        username,
+        passwordEncoder.encode(password),
+        username + "@example.com",
+        LocalDateTime.now(clock),
+        Set.of(userRole)
+    );
+
+    userRepository.save(user);
+  }
+}

--- a/src/test/java/io/github/ajmiller611/usermanagement/UserManagementApplicationTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/UserManagementApplicationTests.java
@@ -1,35 +1,11 @@
 package io.github.ajmiller611.usermanagement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import io.github.ajmiller611.usermanagement.model.Role;
-import io.github.ajmiller611.usermanagement.model.User;
-import io.github.ajmiller611.usermanagement.repository.RoleRepository;
-import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.env.Environment;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -48,11 +24,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class UserManagementApplicationTests {
 
-  @Mock private RoleRepository roleRepository;
-  @Mock private UserRepository userRepository;
-  @Mock private PasswordEncoder passwordEncoder;
-  @Mock private Environment env;
-  @Mock private Clock clock;
   @InjectMocks private UserManagementApplication application;
 
   /**
@@ -72,131 +43,5 @@ class UserManagementApplicationTests {
       mockedSpringApplication.verify(() ->
           SpringApplication.run(UserManagementApplication.class, new String[]{}));
     }
-  }
-
-  /*
-   * Tests the behavior when the ADMIN role does not exist in the database.
-   * Verifies that an ADMIN role and USER role are added to the database.
-   * Verifies that a User with the role of admin is added to the database.
-   */
-  @Test
-  void testRunWhenAdminRoleDoesNotExist() throws Exception {
-    // Mock behaviors when the admin role is not present
-    when(roleRepository.findByAuthority("ADMIN")).thenReturn(Optional.empty());
-
-    // Use a fixed time stamp to be able to have an expected value to test.
-    LocalDateTime fixedTimestamp = LocalDateTime.of(2024, 11, 17, 0, 0, 0, 0);
-    Clock fixedClock = Clock.fixed(fixedTimestamp
-        .atZone(ZoneId.systemDefault())
-        .toInstant(), ZoneId.systemDefault());
-    when(clock.instant()).thenReturn(fixedClock.instant());
-    when(clock.getZone()).thenReturn(fixedClock.getZone());
-
-    Role adminRole = new Role("ADMIN");
-    adminRole.setRoleId(1); // Manually set the id in the mocked role instance
-    Role userRole = new Role("USER");
-    userRole.setRoleId(2); // Manually set the id in the mocked role instance
-    when(roleRepository.save(any(Role.class))).thenReturn(adminRole).thenReturn(userRole);
-
-    when(env.getProperty("ADMIN_PASSWORD")).thenReturn("test-password");
-
-    User adminUser = new User(
-        1L,
-        "admin",
-        "encodedPassword",
-        "admin@example.com",
-        fixedTimestamp,
-        Set.of(userRole, adminRole)
-    );
-    when(userRepository.save(any(User.class))).thenReturn(adminUser);
-    when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
-
-    // Set up log capturing
-    try (LogCaptor logCaptor = LogCaptor.forClass(UserManagementApplication.class)) {
-
-      /*
-       * Retrieve the CommandLineRunner Bean, which returns a lambda expression for execution.
-       * Getting the Bean directly from the application bypasses Spring's profile-based
-       * bean management. This allows testing of the bean in the test profile,
-       * even if the bean is normally restricted to the 'dev' profile
-       */
-      CommandLineRunner commandLineRunner = application.run(
-          roleRepository,
-          userRepository,
-          passwordEncoder,
-          clock
-      );
-      // Invoke the run method of the CommandLineRunner Bean, which executes the lambda expression
-      commandLineRunner.run();
-
-      // Verify that Roles were saved with correct values
-      ArgumentCaptor<Role> roleCaptor = ArgumentCaptor.forClass(Role.class);
-      verify(roleRepository, times(2)).save(roleCaptor.capture());
-      List<Role> savedRoles = roleCaptor.getAllValues();
-      assertThat(savedRoles).extracting(Role::getAuthority)
-          .containsExactlyInAnyOrder("ADMIN", "USER");
-
-      // Verify that the Admin User was saved with the correct values
-      ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-      verify(userRepository).save(userCaptor.capture());
-
-      assertEquals(1L, userCaptor.getValue().getUserId(),
-          "The user ID should be 1 for the admin user.");
-
-      assertEquals("admin", userCaptor.getValue().getUsername(),
-          "The username for the admin user should be 'admin'.");
-
-      assertEquals("encodedPassword", userCaptor.getValue().getPassword(),
-          "The password should be encoded as 'encodedPassword'.");
-
-      assertEquals("admin@example.com", userCaptor.getValue().getEmail(),
-          "The email address for the admin user should be 'admin@example.com'.");
-
-      assertEquals(fixedTimestamp, userCaptor.getValue().getCreatedAt(),
-          "The creation timestamp for the admin user should match the fixed timestamp.");
-
-      assertEquals(Set.of(userRole, adminRole), userCaptor.getValue().getAuthorities(),
-          "The admin user should have both 'USER' and 'ADMIN' roles.");
-
-      // Verify that logging happened correctly
-      assertThat(logCaptor.getInfoLogs())
-          .withFailMessage("Logs should indicate the creation of both roles and the admin user.")
-          .containsExactly(
-              "Role created: Role(roleId=1, authority=ADMIN)",
-              "Role created: Role(roleId=2, authority=USER)",
-              "Admin User created: " + userCaptor.getValue().toString()
-          );
-    }
-  }
-
-  /*
-   * Tests the behavior when the ADMIN role does exist.
-   * Verifies that a save of any role does not happen to the database.
-   * Verifies that a save of a User does not happen to the database.
-   */
-  @Test
-  void testRunWhenAdminRoleDoesExist() throws Exception {
-    // Mock behaviours when Admin role exists
-    when(roleRepository.findByAuthority("ADMIN"))
-        .thenReturn(Optional.of(new Role("ADMIN")));
-
-    /*
-     * Retrieve the CommandLineRunner Bean, which returns a lambda expression for execution.
-     * Getting the Bean directly from the application bypasses Spring's profile-based
-     * bean management. This allows testing of the bean in the test profile,
-     * even if the bean is normally restricted to the 'dev' profile
-     */
-    CommandLineRunner commandLineRunner = application.run(
-        roleRepository,
-        userRepository,
-        passwordEncoder,
-        clock
-    );
-    // Invoke the run method of the CommandLineRunner Bean, which executes the lambda expression
-    commandLineRunner.run();
-
-    // Verify the repositories do not perform any save operations.
-    verify(roleRepository, never()).save(any(Role.class));
-    verify(userRepository, never()).save(any(User.class));
   }
 }

--- a/src/test/java/io/github/ajmiller611/usermanagement/config/BootstrapRunnerConfigTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/config/BootstrapRunnerConfigTests.java
@@ -1,0 +1,37 @@
+package io.github.ajmiller611.usermanagement.config;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.github.ajmiller611.usermanagement.service.BootstrapService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.CommandLineRunner;
+
+/**
+ * Unit tests for {@link BootstrapRunnerConfig}.
+ *
+ * <p>Verifies that the {@link CommandLineRunner} bean correctly delegates
+ * application startup initialization to {@link BootstrapService}.</p>
+ */
+class BootstrapRunnerConfigTests {
+
+  /**
+   * Ensures that the CommandLineRunner invokes BootstrapService initialization logic.
+   *
+   * <p>This test validates that when the runner is executed, it calls
+   * {@link BootstrapService#initialize()}, confirming that startup behavior
+   * is properly wired.</p>
+   */
+  @Test
+  void testCommandLineRunnerDelegatesToBootstrapService() throws Exception {
+    BootstrapService bootstrapService = mock(BootstrapService.class);
+
+    BootstrapRunnerConfig config = new BootstrapRunnerConfig(bootstrapService);
+
+    CommandLineRunner runner = config.initialize();
+
+    runner.run();
+
+    verify(bootstrapService).initialize();
+  }
+}

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/DemoResetControllerTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/DemoResetControllerTests.java
@@ -1,0 +1,76 @@
+package io.github.ajmiller611.usermanagement.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.ajmiller611.usermanagement.config.SecurityConfig;
+import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.service.DemoResetService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Unit tests for {@link DemoResetController}.
+ *
+ * <p>Validates that the demo reset endpoint behaves correctly, including:
+ * successful execution for authorized users and proper access control
+ * for unauthorized requests.</p>
+ */
+@WebMvcTest(DemoResetController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("test")
+class DemoResetControllerTests {
+
+  @Autowired private MockMvc mockMvc;
+  @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
+  @MockBean private JwtDecoder jwtDecoder;
+  @MockBean private TokenService tokenService;
+  @MockBean private UserDetailsService userDetailsService;
+  @MockBean private DemoResetService demoResetService;
+
+  /**
+   * Verifies that an authenticated ADMIN user can successfully
+   * trigger the demo reset process.
+   */
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void givenAdminUser_whenResetDemo_thenReturnOk() throws Exception {
+    mockMvc.perform(post("/admin/demo/reset"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Demo data reset successfully."));
+
+    verify(demoResetService).resetDemoData();
+  }
+
+  /**
+   * Verifies that a non-admin user is forbidden from accessing
+   * the demo reset endpoint.
+   */
+  @Test
+  @WithMockUser(roles = "USER")
+  void givenNonAdminUser_whenResetDemo_thenReturnForbidden() throws Exception {
+    mockMvc.perform(post("/admin/demo/reset"))
+        .andExpect(status().isForbidden());
+  }
+
+  /**
+   * Verifies that an unauthenticated request is rejected
+   * when attempting to access the demo reset endpoint.
+   */
+  @Test
+  void givenNoAuthentication_whenResetDemo_thenReturnUnauthorized() throws Exception {
+    mockMvc.perform(post("/admin/demo/reset"))
+        .andExpect(status().isUnauthorized());
+  }
+}

--- a/src/test/java/io/github/ajmiller611/usermanagement/service/BootstrapServiceTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/service/BootstrapServiceTests.java
@@ -1,0 +1,230 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.ajmiller611.usermanagement.model.Role;
+import io.github.ajmiller611.usermanagement.model.User;
+import io.github.ajmiller611.usermanagement.repository.RoleRepository;
+import io.github.ajmiller611.usermanagement.repository.UserRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.Set;
+import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Unit tests for {@link BootstrapService}.
+ *
+ * <p>This test suite verifies system initialization logic responsible for:
+ * <ul>
+ *   <li>Ensuring required roles ("ADMIN", "USER") exist</li>
+ *   <li>Creating missing roles when necessary</li>
+ *   <li>Ensuring a default admin user exists</li>
+ *   <li>Validating correct behavior when data already exists</li>
+ * </ul>
+ *
+ * <p>Tests use Mockito to mock repository and external dependencies,
+ * and verify behavior through interactions and captured arguments.</p>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class BootstrapServiceTests {
+
+  @Mock private RoleRepository roleRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+  @Mock private Environment env;
+  @Mock private Clock clock;
+  @InjectMocks private BootstrapService bootstrapService;
+
+  /**
+   * Verifies that no roles are created when both ADMIN and USER roles already exist.
+   */
+  @Test
+  void testEnsureRolesExistWhenRolesExist() {
+    when(roleRepository.findByAuthority("ADMIN")).thenReturn(Optional.of(new Role("ADMIN")));
+    when(roleRepository.findByAuthority("USER")).thenReturn(Optional.of(new Role("USER")));
+
+    bootstrapService.ensureRolesExist();
+
+    verify(roleRepository, times(1)).findByAuthority("ADMIN");
+    verify(roleRepository, times(1)).findByAuthority("USER");
+
+    verify(roleRepository, never()).save(any(Role.class));
+  }
+
+  /**
+   * Verifies that the ADMIN role is created when it does not exist,
+   * while existing roles remain unchanged.
+   */
+  @Test
+  void testEnsureRolesExistWhenAdminRoleDoesNotExist() {
+    // Mock behaviors when the admin role is not present
+    when(roleRepository.findByAuthority("ADMIN")).thenReturn(Optional.empty());
+    when(roleRepository.findByAuthority("USER")).thenReturn(Optional.of(new Role("USER")));
+
+    Role adminRole = new Role("ADMIN");
+
+    when(roleRepository.save(any(Role.class))).thenReturn(adminRole);
+
+    // Set up log capturing
+    try (LogCaptor logCaptor = LogCaptor.forClass(BootstrapService.class)) {
+      bootstrapService.ensureRolesExist();
+
+      // Verify that the ADMIN role was saved
+      ArgumentCaptor<Role> roleCaptor = ArgumentCaptor.forClass(Role.class);
+      verify(roleRepository, times(1)).save(roleCaptor.capture());
+      Role savedRole = roleCaptor.getValue();
+      assertThat(savedRole.getAuthority()).isEqualTo("ADMIN");
+
+      // Verify that logging happened correctly
+      assertThat(logCaptor.getInfoLogs())
+          .withFailMessage("Logs should indicate the creation of the ADMIN role.")
+          .anyMatch(log -> log.contains("Role created"));
+    }
+  }
+
+  /**
+   * Verifies that the USER role is created when it does not exist,
+   * while existing roles remain unchanged.
+   */
+  @Test
+  void testEnsureRolesExistWhenUserRoleDoesNotExist() {
+    // Mock behaviors when the user role is not present
+    when(roleRepository.findByAuthority("ADMIN")).thenReturn(Optional.of(new Role("ADMIN")));
+    when(roleRepository.findByAuthority("USER")).thenReturn(Optional.empty());
+
+    Role userRole = new Role("USER");
+
+    when(roleRepository.save(any(Role.class))).thenReturn(userRole);
+
+    // Set up log capturing
+    try (LogCaptor logCaptor = LogCaptor.forClass(BootstrapService.class)) {
+      bootstrapService.ensureRolesExist();
+
+      // Verify that the USER role was saved
+      ArgumentCaptor<Role> roleCaptor = ArgumentCaptor.forClass(Role.class);
+      verify(roleRepository, times(1)).save(roleCaptor.capture());
+      Role savedRole = roleCaptor.getValue();
+      assertThat(savedRole.getAuthority()).isEqualTo("USER");
+
+      // Verify that logging happened correctly
+      assertThat(logCaptor.getInfoLogs())
+          .withFailMessage("Logs should indicate the creation of the USER role")
+          .anyMatch(log -> log.contains("Role created"));
+    }
+  }
+
+  /**
+   * Verifies that no admin user is created when one already exists.
+   *
+   * <p>Ensures early return prevents unnecessary repository and service calls.</p>
+   */
+  @Test
+  void testEnsureAdminExistWhenAdminExist() {
+    when(userRepository.findByUsername("admin")).thenReturn(Optional.of(new User()));
+
+    bootstrapService.ensureAdminExists();
+
+    verify(userRepository).findByUsername("admin");
+    verify(userRepository, never()).save(any());
+
+    verifyNoInteractions(roleRepository);
+    verifyNoInteractions(passwordEncoder, env);
+  }
+
+  /**
+   * Verifies full admin creation when no admin user exists.
+   *
+   * <p>Ensures:
+   * <ul>
+   *   <li>Roles are loaded from repository</li>
+   *   <li>Password is encoded using PasswordEncoder</li>
+   *   <li>Environment variable is used for admin password</li>
+   *   <li>User entity is created with correct fields and persisted</li>
+   * </ul>
+   * </p>
+   */
+  @Test
+  void testEnsureAdminExistWhenAdminDoesNotExist() {
+    when(userRepository.findByUsername("admin")).thenReturn(Optional.empty());
+
+    when(roleRepository.findByAuthority("ADMIN")).thenReturn(Optional.of(new Role("ADMIN")));
+    when(roleRepository.findByAuthority("USER")).thenReturn(Optional.of(new Role("USER")));
+
+    when(env.getProperty("ADMIN_PASSWORD")).thenReturn("test-password");
+
+    // Use a fixed time stamp to be able to have an expected value to test.
+    LocalDateTime fixedTimestamp = LocalDateTime.of(2024, 11, 17, 0, 0, 0, 0);
+    Clock fixedClock = Clock.fixed(fixedTimestamp
+        .atZone(ZoneId.systemDefault())
+        .toInstant(), ZoneId.systemDefault());
+    when(clock.instant()).thenReturn(fixedClock.instant());
+    when(clock.getZone()).thenReturn(fixedClock.getZone());
+
+    Role adminRole = new Role("ADMIN");
+    Role userRole = new Role("USER");
+
+    User adminUser = new User(
+        null,
+        "admin",
+        "encodedPassword",
+        "admin@example.com",
+        fixedTimestamp,
+        Set.of(userRole, adminRole)
+    );
+
+    when(userRepository.save(any(User.class))).thenReturn(adminUser);
+    when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+
+    // Set up log capturing
+    try (LogCaptor logCaptor = LogCaptor.forClass(BootstrapService.class)) {
+      bootstrapService.ensureAdminExists();
+
+      // Verify that the Admin User was saved with the correct values
+      ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+      verify(userRepository).save(userCaptor.capture());
+
+      assertNull(userCaptor.getValue().getUserId(),
+          "The user ID should be null for the admin user.");
+
+      assertEquals("admin", userCaptor.getValue().getUsername(),
+          "The username for the admin user should be 'admin'.");
+
+      assertEquals("encodedPassword", userCaptor.getValue().getPassword(),
+          "The password should be encoded as 'encodedPassword'.");
+
+      assertEquals("admin@example.com", userCaptor.getValue().getEmail(),
+          "The email address for the admin user should be 'admin@example.com'.");
+
+      assertEquals(fixedTimestamp, userCaptor.getValue().getCreatedAt(),
+          "The creation timestamp for the admin user should match the fixed timestamp.");
+
+      assertEquals(Set.of(userRole, adminRole), userCaptor.getValue().getAuthorities(),
+          "The admin user should have both 'USER' and 'ADMIN' roles.");
+
+      // Verify that logging happened correctly
+      assertThat(logCaptor.getInfoLogs())
+          .withFailMessage("Logs should indicate the creation of the admin user.")
+          .anyMatch(log -> log.contains("Admin created"));
+    }
+  }
+}

--- a/src/test/java/io/github/ajmiller611/usermanagement/service/DemoResetServiceTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/service/DemoResetServiceTests.java
@@ -1,0 +1,86 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.ajmiller611.usermanagement.model.Role;
+import io.github.ajmiller611.usermanagement.model.User;
+import io.github.ajmiller611.usermanagement.repository.RoleRepository;
+import io.github.ajmiller611.usermanagement.repository.UserRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Unit tests for {@link DemoResetService}, validating the behavior of the
+ * demo reset functionality.
+ *
+ * <p>This test ensures that the reset process:
+ * <ul>
+ *   <li>Clears existing user data and user-role mappings</li>
+ *   <li>Delegates role and admin restoration to {@code BootstrapService}</li>
+ *   <li>Creates expected demo users with correctly mapped data</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class DemoResetServiceTests {
+
+  @Mock private UserRepository userRepository;
+  @Mock private RoleRepository roleRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+  @Mock private Clock clock;
+  @Mock private BootstrapService bootstrapService;
+
+  @InjectMocks private DemoResetService demoResetService;
+
+  /**
+   * Verifies that resetting demo data behaves correctly.
+   * <ul>
+   *   <li>Deletes existing user and user-role data</li>
+   *   <li>Calls bootstrap service to restore required system state</li>
+   *   <li>Creates the expected demo users with correct usernames</li>
+   * </ul>
+   *
+   * <p>Also validates that user creation logic correctly encodes passwords
+   * and assigns timestamps using the system clock.</p>
+   */
+  @Test
+  void givenResetDemoData_whenResetDemoData_thenResetDemoData() {
+    Role userRole = new Role("USER");
+
+    when(roleRepository.findByAuthority("USER"))
+        .thenReturn(Optional.of(userRole));
+
+    when(passwordEncoder.encode(any()))
+        .thenReturn("encodedPassword");
+
+    when(clock.instant()).thenReturn(Instant.now());
+    when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+
+    demoResetService.resetDemoData();
+
+    verify(userRepository).deleteAllUserRoleMappings();
+    verify(userRepository).deleteAll();
+
+    verify(bootstrapService).ensureRolesExist();
+    verify(bootstrapService).ensureAdminExists();
+
+    ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository, times(2)).save(userCaptor.capture());
+
+    assertThat(userCaptor.getAllValues())
+        .extracting(User::getUsername)
+        .containsExactlyInAnyOrder("testUser1", "testUser2");
+  }
+}


### PR DESCRIPTION
## Summary

Refactor application bootstrap logic for initial system setup and adds an admin-only demo reset feature for quickly restoring the system to a known state.

---

## Changes

### 1. Bootstrap Initialization
- Added BootstrapService to initialize required system data
- Automatically creates default roles (e.g. USER, ADMIN)
- Creates initial admin user if none exists
- Ensures application is usable immediately after first startup

### 2. Demo Reset Feature
- Added DemoResetService to reset application data to demo state
- Added DemoResetController with endpoint:

  `POST /admin/demo/reset`

- Secured endpoint with:
  `@PreAuthorize("hasRole('ADMIN')")`