### PR TITLE
Add invitation-based user registration flow

### DIFF
--- a/src/integrationTest/java/io/github/ajmiller611/usermanagement/service/InvitationServiceIntegrationTests.java
+++ b/src/integrationTest/java/io/github/ajmiller611/usermanagement/service/InvitationServiceIntegrationTests.java
@@ -1,0 +1,147 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.ajmiller611.usermanagement.dto.InvitationRequestDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationValidationResponseDto;
+import io.github.ajmiller611.usermanagement.model.Invitation;
+import io.github.ajmiller611.usermanagement.model.Role;
+import io.github.ajmiller611.usermanagement.repository.InvitationRepository;
+import io.github.ajmiller611.usermanagement.repository.RoleRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Integration tests for the {@link InvitationService} class.
+ *
+ * <p>This test class verifies the functionality in the {@link InvitationService},
+ * focusing on database interactions.</p>
+ *
+ * <h2>Key Features Tested</h2>
+ * <ul>
+ *   <li>
+ *     <strong>Invitation Creation:</strong> Ensures {@code createInvitation()}
+ *     creates the invitation and saves it to the database properly.
+ *   </li>
+ *   <li>
+ *     <strong>Invitation Validation:</strong> Validates a valid token is found in the database
+ *     and correct details are in the response dto.
+ *   </li>
+ *   <li>
+ *     <strong>Mark Invitation as Used:</strong> Ensures an invitation is updated successfully
+ *     when marked as used.
+ *   </li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("integration")
+@Transactional
+class InvitationServiceIntegrationTests {
+
+  @Autowired private InvitationService invitationService;
+  @Autowired private InvitationRepository invitationRepository;
+  @Autowired private RoleRepository roleRepository;
+
+  Role role;
+
+  @BeforeEach
+  void setUp() {
+    // Roles already exist in the database due to bootstrap service running on startup
+    role = roleRepository.findByAuthority("USER").orElseThrow();
+  }
+
+  /** Verifies {@code createInvitation()} creates the invitation and saves it. */
+  @Test
+  void givenValidRequestWhenCreateInvitationThenReturnInvitationResponseDto() {
+    InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
+        "test@email.com",
+        "USER"
+    );
+
+    invitationService.createInvitation(invitationRequestDto);
+
+    Invitation invitation =
+        invitationRepository.findByEmail(invitationRequestDto.getEmail()).orElseThrow();
+
+    assertNotNull(invitation, "The invitation should not be null");
+    assertNotNull(invitation.getId(), "The invitation id should not be null");
+    assertNotNull(invitation.getToken(), "The invitation token should not be null");
+    assertEquals(
+        invitationRequestDto.getEmail(),
+        invitation.getEmail(),
+        "The invitation email should be the same"
+    );
+    assertEquals(
+        invitationRequestDto.getRole(),
+        invitation.getRole().getAuthority(),
+        "The invitation role should be the same"
+    );
+    assertTrue(
+        invitation.getCreatedAt().isBefore(LocalDateTime.now()),
+        "The invitation createdAt timestamp should be before this assertion");
+
+
+    assertTrue(
+        invitation.getExpiresAt().isAfter(LocalDateTime.now().plusDays(6).plusHours(23)),
+        "The expiresAt timestamp should be 7 days after the createdAt timestamp"
+    );
+  }
+
+  /** Verifies {@code validateInvitation()} returns the details when a valid token is given. */
+  @Test
+  void givenValidTokenWhenValidateInvitationThenReturnInvitationValidationResponseDto() {
+    Invitation invitation = new Invitation(
+        null,
+        "test@email.com",
+        "token",
+        role,
+        LocalDateTime.now(),
+        LocalDateTime.now().plusDays(7),
+        false
+    );
+    invitationRepository.save(invitation);
+
+    InvitationValidationResponseDto responseDto =
+        invitationService.validateInvitation(invitation.getToken());
+
+    assertNotNull(responseDto, "The response should not be null");
+    assertEquals(invitation.getEmail(), responseDto.getEmail(), "The email should be the same");
+    assertEquals(
+        invitation.getRole().getAuthority(),
+        responseDto.getRole(),
+        "The role should be the same"
+    );
+    assertTrue(
+        responseDto.getExpiresAt().isAfter(LocalDateTime.now().plusDays(6).plusHours(23)),
+        "The expiresAt timestamp should be 7 days after the createdAt timestamp"
+    );
+  }
+
+  /** Verifies {@code markInvitationAsUsed} updates the invitation and the change is saved. */
+  @Test
+  void givenInvitationWhenMarkInvitationAsUsedThenConfirmInvitationAsUsed() {
+    Invitation invitation = new Invitation(
+        null,
+        "test@email.com",
+        "token",
+        role,
+        LocalDateTime.now(),
+        LocalDateTime.now().plusDays(7),
+        false
+    );
+    Invitation saved = invitationRepository.save(invitation);
+
+    invitationService.markInvitationAsUsed(saved);
+
+    Invitation updated = invitationRepository.findById(saved.getId()).orElseThrow();
+
+    assertTrue(updated.isUsed());
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/config/SecurityConfig.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/config/SecurityConfig.java
@@ -126,6 +126,7 @@ public class SecurityConfig {
           auth.requestMatchers("/auth/**").permitAll();
           auth.requestMatchers(HttpMethod.GET, "/users/**").hasAnyRole(ADMIN, "USER");
           auth.requestMatchers("/users/**").hasRole(ADMIN);
+          auth.requestMatchers(HttpMethod.POST, "/invitations").hasRole(ADMIN);
           auth.anyRequest().authenticated();
         });
     http

--- a/src/main/java/io/github/ajmiller611/usermanagement/controller/AuthenticationController.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/controller/AuthenticationController.java
@@ -2,15 +2,20 @@ package io.github.ajmiller611.usermanagement.controller;
 
 import io.github.ajmiller611.usermanagement.dto.AuthTokensDto;
 import io.github.ajmiller611.usermanagement.dto.LoginResponseDto;
+import io.github.ajmiller611.usermanagement.dto.RegistrationRequestDto;
 import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
+import io.github.ajmiller611.usermanagement.dto.UserResponseDto;
 import io.github.ajmiller611.usermanagement.model.Role;
 import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.AuthenticationService;
+import io.github.ajmiller611.usermanagement.service.InvitationService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -25,11 +30,13 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
  * REST controller responsible for user authentication and refresh tokens endpoints.
@@ -48,6 +55,7 @@ public class AuthenticationController {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final AuthenticationService authenticationService;
+  private final InvitationService invitationService;
   private final JwtService jwtService;
   private final UserService userService;
 
@@ -260,5 +268,41 @@ public class AuthenticationController {
     response.addCookie(refreshTokenCookie);
 
     return ResponseEntity.ok("Logged out successfully");
+  }
+
+  /**
+   * Completes user registration using an invitation token.
+   *
+   * <p>This endpoint validates the invitation token, creates a new user with the
+   * provided username and password, and returns the created user details.</p>
+   *
+   * @param requestDto the {@link RegistrationRequestDto} containing token, username, and password
+   * @return a {@link UserResponseDto} containing the created user's details
+   */
+  @Transactional
+  @PostMapping("/register/invitation")
+  public ResponseEntity<UserResponseDto> completeRegistration(
+      @Valid @RequestBody RegistrationRequestDto requestDto) {
+    logger.info("Endpoint /register/invitation received POST request: {}", requestDto);
+
+    UserDto userDto = authenticationService.completeRegistration(requestDto);
+
+    URI location = ServletUriComponentsBuilder
+        .fromCurrentContextPath()
+        .path("/users/{id}")
+        .buildAndExpand(userDto.getUserId())
+        .toUri();
+
+    UserResponseDto responseDto = new UserResponseDto(
+        userDto.getUserId(),
+        userDto.getUsername(),
+        userDto.getEmail()
+    );
+
+    ResponseEntity<UserResponseDto> response =
+        ResponseEntity.created(location).body(responseDto);
+
+    logger.info("Endpoint /register/invitation response: {}", response);
+    return response;
   }
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/controller/AuthenticationController.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/controller/AuthenticationController.java
@@ -5,7 +5,7 @@ import io.github.ajmiller611.usermanagement.dto.LoginResponseDto;
 import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.model.Role;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.AuthenticationService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import jakarta.servlet.http.Cookie;
@@ -48,7 +48,7 @@ public class AuthenticationController {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final AuthenticationService authenticationService;
-  private final TokenService tokenService;
+  private final JwtService jwtService;
   private final UserService userService;
 
   public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
@@ -151,7 +151,7 @@ public class AuthenticationController {
       }
 
       // Decode the refresh token to extract claims
-      Jwt decodedJwt = tokenService.jwtDecoder().decode(refreshToken);
+      Jwt decodedJwt = jwtService.jwtDecoder().decode(refreshToken);
 
       // Extract the username or subject from the refresh token
       String username = decodedJwt.getSubject();
@@ -171,8 +171,8 @@ public class AuthenticationController {
           null,
           userDto.getAuthorities()
       );
-      String newAccessToken = tokenService.generateAccessToken(auth);
-      String newRefreshToken = tokenService.generateRefreshToken(auth);
+      String newAccessToken = jwtService.generateAccessToken(auth);
+      String newRefreshToken = jwtService.generateRefreshToken(auth);
 
       response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken);
 

--- a/src/main/java/io/github/ajmiller611/usermanagement/controller/InvitationController.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/controller/InvitationController.java
@@ -1,0 +1,59 @@
+package io.github.ajmiller611.usermanagement.controller;
+
+import io.github.ajmiller611.usermanagement.dto.InvitationRequestDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationResponseDto;
+import io.github.ajmiller611.usermanagement.service.InvitationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for handling invitation-related HTTP requests.
+ *
+ * <p>This controller exposes endpoints for creating an invitation (ADMIN access only) and
+ * validating an invitation via a token. It also facilitates interaction with the
+ * {@link InvitationService} for invitation-related operations.</p>
+ */
+@RestController
+@RequestMapping("/invitations")
+@RequiredArgsConstructor
+@Validated
+public class InvitationController {
+
+  private final Logger logger = LoggerFactory.getLogger(InvitationController.class);
+  private final InvitationService invitationService;
+
+  /**
+   * Creates a new invitation in the system.
+   *
+   * <p>This endpoint receives a {@link InvitationRequestDto} object containing the email and role
+   * for the new user. It delegates invitation creation to the {@link InvitationService} and,
+   * upon successful creation, returns a response with the token and metadata.
+   * </p>
+   *
+   * @param invitationRequestDto the {@link InvitationRequestDto} containing the email and role
+   * @return a {@link ResponseEntity} containing a {@link InvitationResponseDto} containing the
+   *         token and metadata
+   */
+  @PostMapping({"/", ""})
+  public ResponseEntity<InvitationResponseDto> createInvitation(
+      @Valid @RequestBody InvitationRequestDto invitationRequestDto
+  ) {
+    logger.info("Endpoint /invitations received POST request: {}", invitationRequestDto);
+    InvitationResponseDto invitationResponseDto =
+        invitationService.createInvitation(invitationRequestDto);
+
+    ResponseEntity<InvitationResponseDto> response =
+        ResponseEntity.status(HttpStatus.CREATED).body(invitationResponseDto);
+    logger.info("Invitation created successfully for email: {}", invitationResponseDto.getEmail());
+    return response;
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/controller/InvitationController.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/controller/InvitationController.java
@@ -2,6 +2,7 @@ package io.github.ajmiller611.usermanagement.controller;
 
 import io.github.ajmiller611.usermanagement.dto.InvitationRequestDto;
 import io.github.ajmiller611.usermanagement.dto.InvitationResponseDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationValidationResponseDto;
 import io.github.ajmiller611.usermanagement.service.InvitationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +11,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -55,5 +58,29 @@ public class InvitationController {
         ResponseEntity.status(HttpStatus.CREATED).body(invitationResponseDto);
     logger.info("Invitation created successfully for email: {}", invitationResponseDto.getEmail());
     return response;
+  }
+
+  /**
+   * Validates an invitation.
+   *
+   * <p>This endpoint receives a token associated with an invitation to check its validation.
+   * It delegates the validation to the {@link InvitationService} and, if valid, returns a response
+   * with email and role of the invitation.</p>
+   *
+   * @param token a token associated with an invitation
+   * @return a {@link ResponseEntity} containing a {@link InvitationValidationResponseDto} with
+   *         the email and role
+   */
+  @GetMapping("/validate")
+  public ResponseEntity<InvitationValidationResponseDto> validateInvitation(
+      @RequestParam String token
+  ) {
+    logger.info("Endpoint /invitations/validate received GET request");
+
+    InvitationValidationResponseDto response =
+        invitationService.validateInvitation(token);
+
+    logger.info("Invitation validated successfully for email: {}", response.getEmail());
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/dto/InvitationRequestDto.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/dto/InvitationRequestDto.java
@@ -1,0 +1,28 @@
+package io.github.ajmiller611.usermanagement.dto;
+
+import io.github.ajmiller611.usermanagement.annotation.ValidEmail;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object (DTO) for creating an invitation.
+ * Contains the email and role required to generate a new invitation.
+ *
+ * <p>This class also utilizes a custom annotation, {@link ValidEmail} for email validation.</p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvitationRequestDto {
+
+  @NotBlank
+  @ValidEmail
+  private String email;
+
+  @NotBlank
+  @Pattern(regexp = "ADMIN|USER")
+  private String role;
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/dto/InvitationResponseDto.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/dto/InvitationResponseDto.java
@@ -1,0 +1,23 @@
+package io.github.ajmiller611.usermanagement.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object (DTO) representing the response after creation of an invitation.
+ *
+ * <p>This DTO contains the token and metadata like email and expiration date for
+ * confirmation purposes.</p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class InvitationResponseDto {
+
+  private String token;
+  private String email;
+  private LocalDateTime expiresAt;
+
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/dto/InvitationValidationResponseDto.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/dto/InvitationValidationResponseDto.java
@@ -1,0 +1,19 @@
+package io.github.ajmiller611.usermanagement.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object (DTO) representing the response to a valid invitation check.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvitationValidationResponseDto {
+
+  private String email;
+  private String role;
+  private LocalDateTime expiresAt;
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/dto/RegistrationRequestDto.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/dto/RegistrationRequestDto.java
@@ -1,0 +1,41 @@
+package io.github.ajmiller611.usermanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object (DTO) for completing registration of a user.
+ *
+ * <p>This object encapsulates the necessary registration data, including the token of
+ * an invitation, username, and password required to create a user. The DTO is received in the
+ * controller layer and processed through the service layer to create a new user in the system.</p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistrationRequestDto {
+
+  @NotBlank(message = "Token is required")
+  private String token;
+
+  @NotBlank(message = "Username is required")
+  @Size(min = 3, max = 20, message = "Username must be between 3 and 20 characters")
+  private String username;
+
+  @NotBlank(message = "Password is required")
+  @Size(min = 8, message = "Password must be at least 8 characters")
+  private String password;
+
+  /**
+   * A method to print out values of nonsensitive fields.
+   *
+   * @return a String representation of the DTO without sensitive fields
+   */
+  @Override
+  public String toString() {
+    return "RegistrationRequestDto(username=" + this.username + ")";
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/exception/GlobalExceptionHandler.java
@@ -290,4 +290,44 @@ public class GlobalExceptionHandler {
     response.setData(errors);
     return ResponseEntity.badRequest().body(response);
   }
+
+  /**
+   * Handles {@link InvitationNotFoundException} when an invitation does not exist in the database.
+   *
+   * @param ex the {@link InvitationNotFoundException} containing the error details
+   * @return a {@link ResponseEntity} containing the error response with the HTTP status of 404
+   */
+  @ExceptionHandler(InvitationNotFoundException.class)
+  public ResponseEntity<ResponseWrapper<String>> handleInvitationNotFoundException(
+      InvitationNotFoundException ex) {
+    logger.error("InvitationNotFoundException: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ResponseWrapper.error(ex.getMessage()));
+  }
+
+  /**
+   * Handles {@link InvitationAlreadyUsedException} when an invitation has been used.
+   *
+   * @param ex the {@link InvitationAlreadyUsedException} containing the error details
+   * @return a {@link ResponseEntity} containing the error response with the HTTP status of 409
+   */
+  @ExceptionHandler(InvitationAlreadyUsedException.class)
+  public ResponseEntity<ResponseWrapper<String>> handleInvitationAlreadyUsedException(
+      InvitationAlreadyUsedException ex) {
+    logger.error("InvitationAlreadyUsedException: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(ResponseWrapper.error(ex.getMessage()));
+  }
+
+  /**
+   * Handles {@link InvitationExpiredException} when an invitation has expired.
+   *
+   * @param ex the {@link InvitationExpiredException} containing the error details
+   * @return a {@link ResponseEntity} containing the error response with the HTTP status of 400
+   */
+  @ExceptionHandler(InvitationExpiredException.class)
+  public ResponseEntity<ResponseWrapper<String>> handleInvitationExpiredException(
+      InvitationExpiredException ex) {
+    logger.error("InvitationExpiredException: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ResponseWrapper.error(ex.getMessage()));
+  }
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/exception/InvitationAlreadyUsedException.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/exception/InvitationAlreadyUsedException.java
@@ -1,0 +1,17 @@
+package io.github.ajmiller611.usermanagement.exception;
+
+import lombok.Getter;
+
+/** Custom exception thrown when an invitation has already been used. */
+@Getter
+public class InvitationAlreadyUsedException extends RuntimeException {
+
+  /**
+   * Constructs a new {@code InvitationAlreadyUsedException} with the specified detail message.
+   *
+   * @param message the detail message explaining the reason for the exception
+   */
+  public InvitationAlreadyUsedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/exception/InvitationExpiredException.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/exception/InvitationExpiredException.java
@@ -1,0 +1,17 @@
+package io.github.ajmiller611.usermanagement.exception;
+
+import lombok.Getter;
+
+/** Custom exception throw when an invitation has expired. */
+@Getter
+public class InvitationExpiredException extends RuntimeException {
+
+  /**
+   * Constructs a new {@code InvitationEpiredException} with specified detail message.
+   *
+   * @param message the detail message explaining the reason for the exception
+   */
+  public InvitationExpiredException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/exception/InvitationNotFoundException.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/exception/InvitationNotFoundException.java
@@ -1,0 +1,17 @@
+package io.github.ajmiller611.usermanagement.exception;
+
+import lombok.Getter;
+
+/** Custom exception thrown when an invitation is not found in the database. */
+@Getter
+public class InvitationNotFoundException extends RuntimeException {
+
+  /**
+   * Constructs a new {@code InvitationNotFoundException} with the specified detail message.
+   *
+   * @param message the detail message explaining the reason for the exception
+   */
+  public InvitationNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/model/Invitation.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/model/Invitation.java
@@ -1,0 +1,58 @@
+package io.github.ajmiller611.usermanagement.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents an invitation sent by an admin to complete a registration process.
+ * This entity is mapped to the 'invitations' table in the database. It contains fields for
+ * ID, email, token, role, creation timestamp, expiration timestamp, and used status.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "invitations")
+public class Invitation {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column
+  private Long id;
+
+  @NotNull
+  @Column(nullable = false)
+  private String email;
+
+  @NotNull
+  @Column(nullable = false, unique = true)
+  private String token;
+
+  @NotNull
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "role_id", nullable = false)
+  private Role role;
+
+  @NotNull
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @NotNull
+  @Column(nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(nullable = false)
+  private boolean used;
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/repository/InvitationRepository.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/repository/InvitationRepository.java
@@ -1,0 +1,33 @@
+package io.github.ajmiller611.usermanagement.repository;
+
+import io.github.ajmiller611.usermanagement.model.Invitation;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface for managing {@link Invitation} entities.
+ *
+ * <p>This interface extends {@link JpaRepository} to provide standard CRUD operations and allows
+ * additional query methods for Invitation data access. It is annotated with {@link Repository} to
+ * indicate its role in Spring Data.</p>
+ */
+@Repository
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+  /**
+   * Retrieves an {@link Invitation} entity by its token.
+   *
+   * @param token the token of the {@link Invitation} to retrieve
+   * @return an {@link Optional} containing the {@link Invitation} if found, or empty if not
+   */
+  Optional<Invitation> findByToken(String token);
+
+  /**
+   * Retrieves an {@link Invitation} entity by its email.
+   *
+   * @param email the email of the {@link Invitation} to retrieve
+   * @return an {@link Optional} containing the {@link Invitation} if found, or empty if not
+   */
+  Optional<Invitation> findByEmail(String email);
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/security/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/security/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-  private final TokenService tokenService;
+  private final JwtService jwtService;
   private final JwtAuthenticationConverter jwtAuthenticationConverter;
 
   /**
@@ -70,8 +70,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     String token = authorizationHeader.substring(7);
 
     try {
-      // Decode the JWT token using the TokenService.
-      Jwt jwt = tokenService.jwtDecoder().decode(token);
+      // Decode the JWT token using the JwtService.
+      Jwt jwt = jwtService.jwtDecoder().decode(token);
 
       // Convert the decoded JWT into an Authentication token using the JwtAuthenticationConverter.
       JwtAuthenticationToken authentication =

--- a/src/main/java/io/github/ajmiller611/usermanagement/security/JwtService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/security/JwtService.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
-public class TokenService {
+public class JwtService {
 
   private final RsaKeyProperties keys;
 

--- a/src/main/java/io/github/ajmiller611/usermanagement/service/AuthenticationService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/service/AuthenticationService.java
@@ -5,7 +5,7 @@ import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.exception.UserNotFoundException;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -36,7 +36,7 @@ public class AuthenticationService {
   private final AuthenticationManager authenticationManager;
   private final UserRepository userRepository;
   private final UserService userService;
-  private final TokenService tokenService;
+  private final JwtService jwtService;
 
   /**
    * Authenticates a user and returns a {@link AuthTokensDto} object containing the
@@ -63,7 +63,7 @@ public class AuthenticationService {
       logger.info("Authentication successful for {}", userRequestDto.getUsername());
 
       // Generate JWT tokens upon successful authentication
-      Map<String, String> tokens = tokenService.generateTokens(auth);
+      Map<String, String> tokens = jwtService.generateTokens(auth);
 
       // Query the database for the user's data
       UserDto userDto = userService.mapToUserDto(

--- a/src/main/java/io/github/ajmiller611/usermanagement/service/AuthenticationService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/service/AuthenticationService.java
@@ -1,9 +1,11 @@
 package io.github.ajmiller611.usermanagement.service;
 
 import io.github.ajmiller611.usermanagement.dto.AuthTokensDto;
+import io.github.ajmiller611.usermanagement.dto.RegistrationRequestDto;
 import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.exception.UserNotFoundException;
+import io.github.ajmiller611.usermanagement.model.Invitation;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
 import io.github.ajmiller611.usermanagement.security.JwtService;
 import java.util.Map;
@@ -36,6 +38,7 @@ public class AuthenticationService {
   private final AuthenticationManager authenticationManager;
   private final UserRepository userRepository;
   private final UserService userService;
+  private final InvitationService invitationService;
   private final JwtService jwtService;
 
   /**
@@ -86,5 +89,32 @@ public class AuthenticationService {
       // Return an empty tokens and null user dto in case of authentication failure
       return new AuthTokensDto("", "", null);
     }
+  }
+
+  /**
+   * Completes registration for a user associated with a valid invitation.
+   *
+   * <p>This method validates the invitation token, creates a new user using the
+   * username and password supplied in the request, and marks the invitation as
+   * used so it cannot be reused.</p>
+   *
+   * @param requestDto the {@link RegistrationRequestDto} containing the invitation
+   *                   token, username, and password
+   * @return a {@link UserDto} containing the created user's details
+   */
+  @Transactional
+  public UserDto completeRegistration(RegistrationRequestDto requestDto) {
+    Invitation invitation = invitationService.getValidInvitation(requestDto.getToken());
+
+    UserRequestDto userRequestDto = new UserRequestDto(
+        requestDto.getUsername(),
+        requestDto.getPassword(),
+        invitation.getEmail()
+    );
+    UserDto userDto = userService.createAndSaveUser(userRequestDto);
+
+    invitationService.markInvitationAsUsed(invitation);
+
+    return userDto;
   }
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/service/InvitationService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/service/InvitationService.java
@@ -1,0 +1,112 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import io.github.ajmiller611.usermanagement.dto.InvitationRequestDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationResponseDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationValidationResponseDto;
+import io.github.ajmiller611.usermanagement.exception.InvitationAlreadyUsedException;
+import io.github.ajmiller611.usermanagement.exception.InvitationExpiredException;
+import io.github.ajmiller611.usermanagement.exception.InvitationNotFoundException;
+import io.github.ajmiller611.usermanagement.exception.RoleNotFoundException;
+import io.github.ajmiller611.usermanagement.model.Invitation;
+import io.github.ajmiller611.usermanagement.model.Role;
+import io.github.ajmiller611.usermanagement.repository.InvitationRepository;
+import io.github.ajmiller611.usermanagement.repository.RoleRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service responsible for managing invitation-related operations,
+ * including invitation creation, validation, and lifecycle management.
+ */
+@Service
+@RequiredArgsConstructor
+public class InvitationService {
+
+  private final Logger logger = LoggerFactory.getLogger(InvitationService.class);
+  private final InvitationRepository invitationRepository;
+  private final InvitationTokenService invitationTokenService;
+  private final RoleRepository roleRepository;
+  private final Clock clock;
+
+  /**
+   * Creates a new invitation for a user and persists it to the database.
+   *
+   * <p>A secure token is generated and associated with the invitation.
+   * The invitation is assigned a role and expires after a fixed duration.</p>
+   *
+   * @param invitationRequestDto the {@link InvitationRequestDto} containing email and role
+   * @return a {@link InvitationResponseDto} containing the invitation token, email,
+   *         and expiration date
+   */
+  public InvitationResponseDto createInvitation(InvitationRequestDto invitationRequestDto) {
+    logger.info("Create invitation request with DTO: {}", invitationRequestDto);
+
+    Role role = roleRepository.findByAuthority(invitationRequestDto.getRole())
+        .orElseThrow(
+            () -> new RoleNotFoundException(invitationRequestDto.getRole() + " not found")
+        );
+
+    String token = invitationTokenService.generateInvitationToken();
+
+    LocalDateTime createdAt = LocalDateTime.now(clock);
+    LocalDateTime expiresAt = createdAt.plusDays(7);
+
+    Invitation invitation = new Invitation();
+    invitation.setEmail(invitationRequestDto.getEmail());
+    invitation.setToken(token);
+    invitation.setRole(role);
+    invitation.setCreatedAt(createdAt);
+    invitation.setExpiresAt(expiresAt);
+    invitation.setUsed(false);
+    invitation = invitationRepository.save(invitation);
+
+    logger.info("Invitation created with ID: {}", invitation.getId());
+    return new InvitationResponseDto(
+        invitation.getToken(),
+        invitation.getEmail(),
+        invitation.getExpiresAt()
+    );
+  }
+
+  /**
+   * Validates that a token is associated with a valid invitation.
+   *
+   * <p>If the invitation does not exist, is expired, or has already been used,
+   * an exception is thrown.</p>
+   *
+   * @param token the token associated with the {@link Invitation}
+   * @return a {@link InvitationValidationResponseDto} containing invitation details
+   */
+  public InvitationValidationResponseDto validateInvitation(String token) {
+    Invitation invitation = invitationRepository.findByToken(token)
+        .orElseThrow(() -> new InvitationNotFoundException("Invitation not found"));
+
+    if (invitation.getExpiresAt().isBefore(LocalDateTime.now(clock))) {
+      throw new InvitationExpiredException("Invitation is expired");
+    }
+
+    if (invitation.isUsed()) {
+      throw new InvitationAlreadyUsedException("Invitation is already used");
+    }
+
+    return new InvitationValidationResponseDto(
+        invitation.getEmail(),
+        invitation.getRole().getAuthority(),
+        invitation.getExpiresAt()
+    );
+  }
+
+  /**
+   * Marks an invitation as used and persists the updated invitation state.
+   *
+   * @param invitation the {@link Invitation} to mark as used
+   */
+  public void markInvitationAsUsed(Invitation invitation) {
+    invitation.setUsed(true);
+    invitationRepository.save(invitation);
+  }
+}

--- a/src/main/java/io/github/ajmiller611/usermanagement/service/InvitationService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/service/InvitationService.java
@@ -79,19 +79,10 @@ public class InvitationService {
    * an exception is thrown.</p>
    *
    * @param token the token associated with the {@link Invitation}
-   * @return a {@link InvitationValidationResponseDto} containing invitation details
+   * @return a {@link InvitationValidationResponseDto} containing validated invitation details
    */
   public InvitationValidationResponseDto validateInvitation(String token) {
-    Invitation invitation = invitationRepository.findByToken(token)
-        .orElseThrow(() -> new InvitationNotFoundException("Invitation not found"));
-
-    if (invitation.getExpiresAt().isBefore(LocalDateTime.now(clock))) {
-      throw new InvitationExpiredException("Invitation is expired");
-    }
-
-    if (invitation.isUsed()) {
-      throw new InvitationAlreadyUsedException("Invitation is already used");
-    }
+    Invitation invitation = getValidInvitation(token);
 
     return new InvitationValidationResponseDto(
         invitation.getEmail(),
@@ -108,5 +99,27 @@ public class InvitationService {
   public void markInvitationAsUsed(Invitation invitation) {
     invitation.setUsed(true);
     invitationRepository.save(invitation);
+  }
+
+  /**
+   * Retrieves a valid invitation or throws an exception if the invitation does not exist,
+   * is used, or is expired.
+   *
+   * @param token the token associated with the {@link Invitation}
+   * @return a valid {@link Invitation}
+   */
+  public Invitation getValidInvitation(String token) {
+    Invitation invitation = invitationRepository.findByToken(token)
+        .orElseThrow(() -> new InvitationNotFoundException("Invitation not found"));
+
+    if (invitation.isUsed()) {
+      throw new InvitationAlreadyUsedException("Invitation is already used");
+    }
+
+    if (invitation.getExpiresAt().isBefore(LocalDateTime.now(clock))) {
+      throw new InvitationExpiredException("Invitation is expired");
+    }
+
+    return invitation;
   }
 }

--- a/src/main/java/io/github/ajmiller611/usermanagement/service/InvitationTokenService.java
+++ b/src/main/java/io/github/ajmiller611/usermanagement/service/InvitationTokenService.java
@@ -1,0 +1,29 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service responsible for generating secure, URL-safe invitation tokens.
+ *
+ * <p>This service uses {@link SecureRandom} to generate cryptographically secure
+ * random bytes, which are then encoded into URL-safe text using Base64 encoding.</p>
+ */
+@Service
+public class InvitationTokenService {
+
+  private final SecureRandom random = new SecureRandom();
+
+  /**
+   * Generates a secure random invitation token that is safe to use in URLs.
+   *
+   * @return a URL-safe invitation token string
+   */
+  public String generateInvitationToken() {
+    byte[] bytes = new byte[32];
+    random.nextBytes(bytes);
+
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+}

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/AuthenticationControllerTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/AuthenticationControllerTests.java
@@ -3,7 +3,9 @@ package io.github.ajmiller611.usermanagement.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,11 +20,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ajmiller611.usermanagement.config.AppConfig;
 import io.github.ajmiller611.usermanagement.config.SecurityConfig;
 import io.github.ajmiller611.usermanagement.dto.AuthTokensDto;
+import io.github.ajmiller611.usermanagement.dto.RegistrationRequestDto;
 import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.model.Role;
 import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.AuthenticationService;
+import io.github.ajmiller611.usermanagement.service.InvitationService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import jakarta.servlet.http.Cookie;
 import java.time.Clock;
@@ -32,6 +36,9 @@ import java.time.ZoneId;
 import java.util.Set;
 import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -63,6 +70,15 @@ import org.springframework.test.web.servlet.MockMvc;
  * </ul>
  * </p>
  *
+ * <h2><h2>Feature Coverage: POST /auth/register/invitation</h2></h2>
+ * <ul>
+ *   <li>Completes user registration using a valid invitation token</li>
+ *   <li>Verifies successful creation returns HTTP 201 (Created)</li>
+ *   <li>Verifies response body contains created user details</li>
+ *   <li>Validates request DTO constraints (token, username, password)</li>
+ *   <li>Ensures authentication service is not called when validation fails</li>
+ * </ul>
+ *
  * <p>Uses {@link MockMvc} to simulate HTTP requests and responses, enabling
  * comprehensive validation of controller behavior without needing to start the full application.
  * </p>
@@ -75,6 +91,7 @@ class AuthenticationControllerTests {
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
   @MockBean private AuthenticationService authenticationService;
+  @MockBean private InvitationService invitationService;
   @MockBean private UserService userService;
   @MockBean private JwtService jwtService;
   @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
@@ -342,5 +359,100 @@ class AuthenticationControllerTests {
     mockMvc.perform(post("/auth/logout"))
         .andExpect(status().isOk())
         .andExpect(cookie().maxAge("refresh_token", 0));
+  }
+
+  /** Verifies a valid registration responds with created (201). */
+  @Test
+  void givenValidRequestWhenCompleteRegistrationThenReturnCreated() throws Exception {
+    RegistrationRequestDto requestDto = new RegistrationRequestDto(
+        "token",
+        "testUser",
+        "password"
+    );
+
+    String validJson = objectMapper.writeValueAsString(requestDto);
+
+    UserDto userDto = new UserDto(
+        1L,
+        "testUser",
+        "test@email.com",
+        LocalDateTime.now(),
+        Set.of(new Role("USER"))
+    );
+
+    when(authenticationService.completeRegistration(requestDto)).thenReturn(userDto);
+
+    mockMvc.perform(post("/auth/register/invitation")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validJson))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.userId").value(userDto.getUserId()))
+        .andExpect(jsonPath("$.username").value(userDto.getUsername()))
+        .andExpect(jsonPath("$.email").value(userDto.getEmail()));
+
+    verify(authenticationService, times(1)).completeRegistration(requestDto);
+  }
+
+  /** Verifies a null, empty, and whitespace token responds with bad request (400). */
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "   "})
+  void givenInvalidTokenWhenCompleteRegistrationThenReturnBadRequest(String token)
+      throws Exception {
+    RegistrationRequestDto requestDto = new RegistrationRequestDto(
+        token,
+        "testUser",
+        "password"
+    );
+    String validJson = objectMapper.writeValueAsString(requestDto);
+
+    mockMvc.perform(post("/auth/register/invitation")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validJson))
+        .andExpect(status().isBadRequest());
+
+    verify(authenticationService, never()).completeRegistration(requestDto);
+  }
+
+  /** Verifies a null, empty, and whitespace username responds with bad request (400). */
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "   "})
+  void givenInvalidUsernameWhenCompleteRegistrationThenReturnBadRequest(String username)
+      throws Exception {
+    RegistrationRequestDto requestDto = new RegistrationRequestDto(
+        "token",
+        username,
+        "password"
+    );
+    String validJson = objectMapper.writeValueAsString(requestDto);
+
+    mockMvc.perform(post("/auth/register/invitation")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validJson))
+        .andExpect(status().isBadRequest());
+
+    verify(authenticationService, never()).completeRegistration(requestDto);
+  }
+
+  /** Verifies a null, empty, and whitespace password responds with bad request (400). */
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "   "})
+  void givenInvalidPasswordWhenCompleteRegistrationThenReturnBadRequest(String password)
+      throws Exception {
+    RegistrationRequestDto requestDto = new RegistrationRequestDto(
+        "token",
+        "testUser",
+        password
+    );
+    String validJson = objectMapper.writeValueAsString(requestDto);
+
+    mockMvc.perform(post("/auth/register/invitation")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validJson))
+        .andExpect(status().isBadRequest());
+
+    verify(authenticationService, never()).completeRegistration(requestDto);
   }
 }

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/AuthenticationControllerTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/AuthenticationControllerTests.java
@@ -21,7 +21,7 @@ import io.github.ajmiller611.usermanagement.dto.AuthTokensDto;
 import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.model.Role;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.AuthenticationService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import jakarta.servlet.http.Cookie;
@@ -76,7 +76,7 @@ class AuthenticationControllerTests {
   @Autowired private ObjectMapper objectMapper;
   @MockBean private AuthenticationService authenticationService;
   @MockBean private UserService userService;
-  @MockBean private TokenService tokenService;
+  @MockBean private JwtService jwtService;
   @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
   @MockBean private JwtDecoder jwtDecoder;
 
@@ -213,14 +213,14 @@ class AuthenticationControllerTests {
     when(validJwt.getSubject()).thenReturn("testUser");
 
     when(jwtDecoder.decode("validToken")).thenReturn(validJwt);
-    when(tokenService.jwtDecoder()).thenReturn(jwtDecoder);
+    when(jwtService.jwtDecoder()).thenReturn(jwtDecoder);
 
     when(userService.getUserByUsername("testUser"))
         .thenReturn(userDto);
 
-    when(tokenService.generateAccessToken(any(Authentication.class)))
+    when(jwtService.generateAccessToken(any(Authentication.class)))
         .thenReturn("newAccessToken");
-    when(tokenService.generateRefreshToken(any(Authentication.class)))
+    when(jwtService.generateRefreshToken(any(Authentication.class)))
         .thenReturn("newRefreshToken");
 
     mockMvc.perform(post("/auth/refresh-token")
@@ -258,7 +258,7 @@ class AuthenticationControllerTests {
     when(expiredJwt.getSubject()).thenReturn("testUser");
 
     when(jwtDecoder.decode("expiredToken")).thenReturn(expiredJwt);
-    when(tokenService.jwtDecoder()).thenReturn(jwtDecoder);
+    when(jwtService.jwtDecoder()).thenReturn(jwtDecoder);
 
     mockMvc.perform(post("/auth/refresh-token")
         .cookie(expiredRefreshTokenCookie))
@@ -274,7 +274,7 @@ class AuthenticationControllerTests {
   void givenInvalidRefreshTokenWhenRefreshTokenThenReturnBadRequest() throws Exception {
     Cookie invalidRefreshTokenCookie = new Cookie("refresh_token", "invalidToken");
     when(jwtDecoder.decode("invalidToken")).thenThrow(new JwtException("Invalid token"));
-    when(tokenService.jwtDecoder()).thenReturn(jwtDecoder);
+    when(jwtService.jwtDecoder()).thenReturn(jwtDecoder);
 
     mockMvc.perform(post("/auth/refresh-token")
             .cookie(invalidRefreshTokenCookie))

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/DemoResetControllerTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/DemoResetControllerTests.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.github.ajmiller611.usermanagement.config.SecurityConfig;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.DemoResetService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +35,7 @@ class DemoResetControllerTests {
   @Autowired private MockMvc mockMvc;
   @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
   @MockBean private JwtDecoder jwtDecoder;
-  @MockBean private TokenService tokenService;
+  @MockBean private JwtService jwtService;
   @MockBean private UserDetailsService userDetailsService;
   @MockBean private DemoResetService demoResetService;
 

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/InvitationControllerTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/InvitationControllerTests.java
@@ -3,8 +3,10 @@ package io.github.ajmiller611.usermanagement.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -14,6 +16,10 @@ import io.github.ajmiller611.usermanagement.config.AppConfig;
 import io.github.ajmiller611.usermanagement.config.SecurityConfig;
 import io.github.ajmiller611.usermanagement.dto.InvitationRequestDto;
 import io.github.ajmiller611.usermanagement.dto.InvitationResponseDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationValidationResponseDto;
+import io.github.ajmiller611.usermanagement.exception.InvitationAlreadyUsedException;
+import io.github.ajmiller611.usermanagement.exception.InvitationExpiredException;
+import io.github.ajmiller611.usermanagement.exception.InvitationNotFoundException;
 import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.InvitationService;
 import java.time.LocalDateTime;
@@ -36,21 +42,34 @@ import org.springframework.test.web.servlet.MockMvc;
  * Unit tests for the {@link InvitationController}.
  *
  * <p>This test class focuses on verifying how the controller handles HTTP requests
- * for creating invitations.</p>
+ * for creating invitations and validating invitation tokens.</p>
  *
- * <h2>What these tests cover</h2>
+ * <h2>Key Features Tested</h2>
  * <ul>
  *   <li>
- *     <strong>Security rules:</strong> Ensures only ADMIN users can access the create invitation
- *     endpoint, and non-admin users receive a 403 Forbidden response.
+ *     <strong>Security rules:</strong> Ensures only ADMIN users can access the
+ *     create invitation endpoint, while validation requests remain accessible
+ *     to authenticated users.
  *   </li>
  *   <li>
- *     <strong>Successful request handling:</strong> Verifies that a valid request returns a
- *     201 Created response with the expected token, email, and expiration date from the service.
+ *     <strong>Successful invitation creation:</strong> Verifies that a valid
+ *     request returns a 201 Created response with the expected token, email,
+ *     and expiration date.
  *   </li>
  *   <li>
- *     <strong>Validation checks:</strong> Ensures invalid requests (missing email, missing role,
- *     or invalid email format) return a 400 Bad Request and that the service method is not called.
+ *     <strong>Request validation:</strong> Ensures invalid invitation creation
+ *     requests (missing email, missing role, or invalid email format) return
+ *     a 400 Bad Request.
+ *   </li>
+ *   <li>
+ *     <strong>Successful invitation validation:</strong> Verifies that a valid
+ *     invitation token returns a 200 OK response with the expected invitation
+ *     details.
+ *   </li>
+ *   <li>
+ *     <strong>Invitation validation errors:</strong> Ensures appropriate HTTP
+ *     responses are returned when a token is not associated with an invitation,
+ *     an invitation has expired, or an invitation has already been used.
  *   </li>
  * </ul>
  */
@@ -70,7 +89,7 @@ class InvitationControllerTests {
   /** Verifies a non-admin user request is responded with forbidden (403). */
   @Test
   @WithMockUser
-  void givenNonAdminUserWhenGetInvitationThenReturnForbidden() throws Exception {
+  void givenNonAdminUserWhenCreateInvitationThenReturnForbidden() throws Exception {
     mockMvc.perform(post("/invitations")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isForbidden());
@@ -121,7 +140,7 @@ class InvitationControllerTests {
   /** Verifies a missing email in the request responds with bad request (400). */
   @Test
   @WithMockUser(roles = "ADMIN")
-  void givenMissingEmailWhenGetInvitationThenReturnBadRequest() throws Exception {
+  void givenMissingEmailWhenCreateInvitationThenReturnBadRequest() throws Exception {
     InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
         null,
         "USER"
@@ -139,7 +158,7 @@ class InvitationControllerTests {
   /** Verifies an invalid email in the request responds with bad request (400). */
   @Test
   @WithMockUser(roles = "ADMIN")
-  void givenInvalidEmailWhenGetInvitationThenReturnBadRequest() throws Exception {
+  void givenInvalidEmailWhenCreateInvitationThenReturnBadRequest() throws Exception {
     InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
         "invalidEmail",
         "USER"
@@ -158,7 +177,7 @@ class InvitationControllerTests {
   /** Verifies a missing role in the request responds with a bad request (400). */
   @Test
   @WithMockUser(roles = "ADMIN")
-  void givenMissingRoleWhenGetInvitationThenReturnBdRequest() throws Exception {
+  void givenMissingRoleWhenCreateInvitationThenReturnBadRequest() throws Exception {
     InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
         "test@email.com",
         null
@@ -174,5 +193,87 @@ class InvitationControllerTests {
     verify(invitationService, never()).createInvitation(any(InvitationRequestDto.class));
   }
 
+  /** Verifies a valid token request validates successfully and returns ok (200). */
+  @Test
+  @WithMockUser
+  void givenValidTokenWhenValidateInvitationThenReturnOk() throws Exception {
+    String validToken = "testToken";
 
+    LocalDateTime expiresAtTimestamp = LocalDateTime.of(2026, 5, 29, 0, 0, 0, 0);
+    InvitationValidationResponseDto invitationValidationResponseDto =
+        new InvitationValidationResponseDto(
+            "test@email.com",
+            "USER",
+            expiresAtTimestamp
+        );
+
+    when(invitationService.validateInvitation(validToken))
+        .thenReturn(invitationValidationResponseDto);
+
+    mockMvc.perform(get("/invitations/validate")
+            .param("token", validToken)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    verify(invitationService, times(1)).validateInvitation(validToken);
+
+  }
+
+  /** Verifies a nonexisting token responds with not found (404). */
+  @Test
+  @WithMockUser
+  void givenNonexistentTokenWhenValidateInvitationThenReturnNotFound() throws Exception {
+    String nonexistentToken = "testToken";
+
+    when(invitationService.validateInvitation(nonexistentToken))
+        .thenThrow(new InvitationNotFoundException("Invitation not found"));
+
+    mockMvc.perform(get("/invitations/validate")
+            .param("token", nonexistentToken)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value("error"))
+        .andExpect(jsonPath("$.message").value("Invitation not found"));
+
+    verify(invitationService, times(1)).validateInvitation(nonexistentToken);
+
+  }
+
+  /** Verifies an expired invitation responds with bad request (400). */
+  @Test
+  @WithMockUser
+  void givenExpiredInvitationWhenValidateInvitationThenReturnBadRequest() throws Exception {
+    String validToken = "testToken";
+
+    when(invitationService.validateInvitation(validToken))
+        .thenThrow(new InvitationExpiredException("Invitation has expired"));
+
+    mockMvc.perform(get("/invitations/validate")
+            .param("token", validToken)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value("error"))
+        .andExpect(jsonPath("$.message").value("Invitation has expired"));
+
+    verify(invitationService, times(1)).validateInvitation(validToken);
+  }
+
+  /** Verifies a used invitation responds with conflict (409). */
+  @Test
+  @WithMockUser
+  void givenUsedInvitationWhenValidateInvitationThenReturnConflict() throws Exception {
+    String validToken = "testToken";
+
+    when(invitationService.validateInvitation(validToken))
+        .thenThrow(new InvitationAlreadyUsedException("Invitation already used"));
+
+    mockMvc.perform(get("/invitations/validate")
+            .param("token", validToken)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.status").value("error"))
+        .andExpect(jsonPath("$.message").value("Invitation already used"));
+
+    verify(invitationService, times(1)).validateInvitation(validToken);
+  }
 }

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/InvitationControllerTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/InvitationControllerTests.java
@@ -1,0 +1,178 @@
+package io.github.ajmiller611.usermanagement.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.ajmiller611.usermanagement.config.AppConfig;
+import io.github.ajmiller611.usermanagement.config.SecurityConfig;
+import io.github.ajmiller611.usermanagement.dto.InvitationRequestDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationResponseDto;
+import io.github.ajmiller611.usermanagement.security.JwtService;
+import io.github.ajmiller611.usermanagement.service.InvitationService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Unit tests for the {@link InvitationController}.
+ *
+ * <p>This test class focuses on verifying how the controller handles HTTP requests
+ * for creating invitations.</p>
+ *
+ * <h2>What these tests cover</h2>
+ * <ul>
+ *   <li>
+ *     <strong>Security rules:</strong> Ensures only ADMIN users can access the create invitation
+ *     endpoint, and non-admin users receive a 403 Forbidden response.
+ *   </li>
+ *   <li>
+ *     <strong>Successful request handling:</strong> Verifies that a valid request returns a
+ *     201 Created response with the expected token, email, and expiration date from the service.
+ *   </li>
+ *   <li>
+ *     <strong>Validation checks:</strong> Ensures invalid requests (missing email, missing role,
+ *     or invalid email format) return a 400 Bad Request and that the service method is not called.
+ *   </li>
+ * </ul>
+ */
+@WebMvcTest(InvitationController.class)
+@Import({SecurityConfig.class, AppConfig.class})
+@ActiveProfiles("test")
+class InvitationControllerTests {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @MockBean private InvitationService invitationService;
+  @MockBean private JwtService jwtService;
+  @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
+  @MockBean private JwtDecoder jwtDecoder;
+  @MockBean private AuthenticationManager authenticationManager;
+
+  /** Verifies a non-admin user request is responded with forbidden (403). */
+  @Test
+  @WithMockUser
+  void givenNonAdminUserWhenGetInvitationThenReturnForbidden() throws Exception {
+    mockMvc.perform(post("/invitations")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  /**
+   * Verifies a valid request is successfully processed and responded with the token
+   * and metadata in the response.
+   */
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void givenValidRequestWhenCreateInvitationThenReturnCreatedResponse() throws Exception {
+    InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
+        "test@email.com",
+        "USER"
+    );
+
+    String validJson = objectMapper.writeValueAsString(invitationRequestDto);
+
+    LocalDateTime expiresAtTimestamp = LocalDateTime.of(2026, 5, 29, 0, 0, 0, 0);
+    InvitationResponseDto  invitationResponseDto = new InvitationResponseDto(
+        "token",
+        "test@email.com",
+        expiresAtTimestamp
+    );
+
+    when(invitationService.createInvitation(any(InvitationRequestDto.class)))
+        .thenReturn(invitationResponseDto);
+
+    try (LogCaptor logCaptor = LogCaptor.forClass(InvitationController.class)) {
+      mockMvc.perform(post("/invitations")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(validJson))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.token").value(invitationResponseDto.getToken()))
+          .andExpect(jsonPath("$.email").value(invitationResponseDto.getEmail()))
+          .andExpect(jsonPath("$.expiresAt")
+              .value(expiresAtTimestamp.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
+
+      assertThat(logCaptor.getInfoLogs())
+          .withFailMessage("")
+          .anyMatch(log -> log.contains("Endpoint /invitations received POST request: ")
+              && log.contains(invitationRequestDto.getEmail())
+              && log.contains(invitationRequestDto.getRole()));
+    }
+  }
+
+  /** Verifies a missing email in the request responds with bad request (400). */
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void givenMissingEmailWhenGetInvitationThenReturnBadRequest() throws Exception {
+    InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
+        null,
+        "USER"
+    );
+    String validJson = objectMapper.writeValueAsString(invitationRequestDto);
+
+    mockMvc.perform(post("/invitations")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validJson))
+        .andExpect(status().isBadRequest());
+
+    verify(invitationService, never()).createInvitation(any(InvitationRequestDto.class));
+  }
+
+  /** Verifies an invalid email in the request responds with bad request (400). */
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void givenInvalidEmailWhenGetInvitationThenReturnBadRequest() throws Exception {
+    InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
+        "invalidEmail",
+        "USER"
+    );
+
+    String validJson = objectMapper.writeValueAsString(invitationRequestDto);
+
+    mockMvc.perform(post("/invitations")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validJson))
+        .andExpect(status().isBadRequest());
+
+    verify(invitationService, never()).createInvitation(any(InvitationRequestDto.class));
+  }
+
+  /** Verifies a missing role in the request responds with a bad request (400). */
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void givenMissingRoleWhenGetInvitationThenReturnBdRequest() throws Exception {
+    InvitationRequestDto invitationRequestDto = new InvitationRequestDto(
+        "test@email.com",
+        null
+    );
+
+    String validJson = objectMapper.writeValueAsString(invitationRequestDto);
+
+    mockMvc.perform(post("/invitations")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validJson))
+        .andExpect(status().isBadRequest());
+
+    verify(invitationService, never()).createInvitation(any(InvitationRequestDto.class));
+  }
+
+
+}

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerCreateTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerCreateTests.java
@@ -18,7 +18,7 @@ import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.model.Role;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -82,7 +82,7 @@ class UserControllerCreateTests {
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
   @MockBean private UserService userService;
-  @MockBean private TokenService tokenService;
+  @MockBean private JwtService jwtService;
   @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
   @MockBean private JwtDecoder jwtDecoder;
   @MockBean private UserRepository userRepository;

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerDeleteTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerDeleteTests.java
@@ -16,7 +16,7 @@ import io.github.ajmiller611.usermanagement.controller.UserController;
 import io.github.ajmiller611.usermanagement.exception.UserNotFoundException;
 import io.github.ajmiller611.usermanagement.repository.RoleRepository;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ class UserControllerDeleteTests {
 
   @Autowired private MockMvc mockMvc;
   @MockBean private UserService userService;
-  @MockBean private TokenService tokenService;
+  @MockBean private JwtService jwtService;
   @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
   @MockBean private JwtDecoder jwtDecoder;
   @MockBean private RoleRepository roleRepository;

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerReadTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerReadTests.java
@@ -21,7 +21,7 @@ import io.github.ajmiller611.usermanagement.model.Role;
 import io.github.ajmiller611.usermanagement.model.User;
 import io.github.ajmiller611.usermanagement.repository.RoleRepository;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -106,7 +106,7 @@ class UserControllerReadTests {
   @InjectMocks private UserController userController;
   @Autowired private MockMvc mockMvc;
   @MockBean private UserService userService;
-  @MockBean private TokenService tokenService;
+  @MockBean private JwtService jwtService;
   @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
   @MockBean private JwtDecoder jwtDecoder;
   @MockBean private RoleRepository roleRepository;

--- a/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerUpdateTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/controller/user/UserControllerUpdateTests.java
@@ -19,7 +19,7 @@ import io.github.ajmiller611.usermanagement.dto.UserResponseDto;
 import io.github.ajmiller611.usermanagement.dto.UserUpdateRequestDto;
 import io.github.ajmiller611.usermanagement.repository.RoleRepository;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import io.github.ajmiller611.usermanagement.service.UserService;
 import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,7 +74,7 @@ class UserControllerUpdateTests {
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
   @MockBean private UserService userService;
-  @MockBean private TokenService tokenService;
+  @MockBean private JwtService jwtService;
   @MockBean private JwtAuthenticationConverter jwtAuthenticationConverter;
   @MockBean private JwtDecoder jwtDecoder;
   @MockBean private RoleRepository roleRepository;

--- a/src/test/java/io/github/ajmiller611/usermanagement/exception/GlobalExceptionHandlerTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/exception/GlobalExceptionHandlerTests.java
@@ -525,4 +525,74 @@ class GlobalExceptionHandlerTests {
               + "message User id must be greater than zero");
     }
   }
+
+  /**
+   * Tests the {@code handleInvitationNotFoundException} method in {@link GlobalExceptionHandler}.
+   * Verifies that a {@link InvitationNotFoundException} results in an HTTP 404 (Not Found)
+   * response with the correct structure and content.
+   */
+  @Test
+  void givenInvitationNotFoundExceptionWhenHandleInvitationNotFoundThenNotFound() {
+    InvitationNotFoundException exception = new InvitationNotFoundException("Invitation not found");
+
+    ResponseEntity<ResponseWrapper<String>> response =
+        globalExceptionHandler.handleInvitationNotFoundException(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode(),
+        "Expected HTTP status to be 404 NOT FOUND when an invitation could not be found");
+
+    assertEquals("error", Objects.requireNonNull(response.getBody()).getStatus(),
+        "Expected response status to be 'error' for invitation not found exception");
+
+    assertThat(response.getBody().getMessage())
+        .withFailMessage("Expected response message to contain 'Invitation not found'")
+        .contains("Invitation not found");
+  }
+
+  /**
+   * Test the {@code handleInvitationAlreadyUsedException} method in {@link GlobalExceptionHandler}.
+   * Verifies that a {@link InvitationAlreadyUsedException} results in an HTTP 409 (Conflict)
+   * response with the correct structure and content.
+   */
+  @Test
+  void givenInvitationAlreadyUsedExceptionWhenHandleInvitationAlreadyUsedThenNotFound() {
+    InvitationAlreadyUsedException exception =
+        new InvitationAlreadyUsedException("Invitation is already used");
+
+    ResponseEntity<ResponseWrapper<String>> response =
+        globalExceptionHandler.handleInvitationAlreadyUsedException(exception);
+
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode(),
+        "Expected HTTP status to be 409 CONFLICT when an invitation could not be found");
+
+    assertEquals("error", Objects.requireNonNull(response.getBody()).getStatus(),
+        "Expected response status to be 'error' for invitation not found exception");
+
+    assertThat(response.getBody().getMessage())
+        .withFailMessage("Expected response message to contain 'Invitation is already used'")
+        .contains("Invitation is already used");
+  }
+
+  /**
+   * Tests the {@code handleInvitationExpiredException} method in {@link GlobalExceptionHandler}.
+   * Verifies that a {@link InvitationExpiredException} results in an HTTP 400 (Bad Request)
+   * response with the correct structure and content.
+   */
+  @Test
+  void givenInvitationExpiredExceptionWhenHandleInvitationExpiredThenNotFound() {
+    InvitationExpiredException exception = new InvitationExpiredException("Invitation is expired");
+
+    ResponseEntity<ResponseWrapper<String>> response =
+        globalExceptionHandler.handleInvitationExpiredException(exception);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(),
+        "Expected HTTP status to be 400 BAD REQUEST when an invitation could not be found");
+
+    assertEquals("error", Objects.requireNonNull(response.getBody()).getStatus(),
+        "Expected response status to be 'error' for invitation not found exception");
+
+    assertThat(response.getBody().getMessage())
+        .withFailMessage("Expected response message to contain 'Invitation is expired'")
+        .contains("Invitation is expired");
+  }
 }

--- a/src/test/java/io/github/ajmiller611/usermanagement/security/JwtAuthenticationFilterTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/security/JwtAuthenticationFilterTests.java
@@ -45,7 +45,7 @@ import org.springframework.test.context.ActiveProfiles;
 class JwtAuthenticationFilterTests {
 
   @InjectMocks private JwtAuthenticationFilter jwtAuthenticationFilter;
-  @Mock private TokenService tokenService;
+  @Mock private JwtService jwtService;
   @Mock private JwtAuthenticationConverter jwtAuthenticationConverter;
   @Mock private JwtDecoder jwtDecoder;
   @Mock private FilterChain filterChain;
@@ -62,14 +62,14 @@ class JwtAuthenticationFilterTests {
   @BeforeAll
   static void setUpOnce() {
     RsaKeyProperties keys = new RsaKeyProperties();
-    TokenService tokenServiceSetUp = new TokenService(keys);
+    JwtService jwtServiceSetUp = new JwtService(keys);
 
     // Generate a valid token
     String username = "testUser";
     Collection<? extends GrantedAuthority> authorities =
         List.of(new SimpleGrantedAuthority("USER"));
     Authentication auth = new UsernamePasswordAuthenticationToken(username, null, authorities);
-    validToken = tokenServiceSetUp.generateAccessToken(auth);
+    validToken = jwtServiceSetUp.generateAccessToken(auth);
   }
 
   /**
@@ -80,7 +80,7 @@ class JwtAuthenticationFilterTests {
   void setUp() {
     SecurityContextHolder.clearContext(); // Reset security context
 
-    jwtAuthenticationFilter = new JwtAuthenticationFilter(tokenService, jwtAuthenticationConverter);
+    jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtService, jwtAuthenticationConverter);
   }
 
   /**
@@ -120,10 +120,10 @@ class JwtAuthenticationFilterTests {
   void givenValidAuthorizationHeaderWhenFilterIsExecutedThenAuthenticationIsSet()
       throws ServletException, IOException {
     when(request.getHeader("Authorization")).thenReturn("Bearer " + validToken);
-    when(tokenService.jwtDecoder()).thenReturn(jwtDecoder);
+    when(jwtService.jwtDecoder()).thenReturn(jwtDecoder);
     Jwt jwt = mock(Jwt.class);
     JwtAuthenticationToken authenticationToken = mock(JwtAuthenticationToken.class);
-    when(tokenService.jwtDecoder().decode(validToken)).thenReturn(jwt);
+    when(jwtService.jwtDecoder().decode(validToken)).thenReturn(jwt);
     when(jwtAuthenticationConverter.convert(jwt)).thenReturn(authenticationToken);
 
     jwtAuthenticationFilter.doFilter(request, response, filterChain);
@@ -143,8 +143,8 @@ class JwtAuthenticationFilterTests {
   void givenInvalidJwtTokenWhenFilterIsExecutedThenRespondUnauthorized()
       throws ServletException, IOException {
     when(request.getHeader("Authorization")).thenReturn("Bearer " + invalidToken);
-    when(tokenService.jwtDecoder()).thenReturn(jwtDecoder);
-    when(tokenService.jwtDecoder().decode(invalidToken))
+    when(jwtService.jwtDecoder()).thenReturn(jwtDecoder);
+    when(jwtService.jwtDecoder().decode(invalidToken))
         .thenThrow(new JwtException("Invalid Token"));
 
     jwtAuthenticationFilter.doFilter(request, response, filterChain);
@@ -171,6 +171,6 @@ class JwtAuthenticationFilterTests {
     jwtAuthenticationFilter.doFilter(request, response, filterChain);
 
     verify(filterChain).doFilter(request, response);
-    verifyNoInteractions(tokenService, jwtAuthenticationConverter);
+    verifyNoInteractions(jwtService, jwtAuthenticationConverter);
   }
 }

--- a/src/test/java/io/github/ajmiller611/usermanagement/security/JwtServiceTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/security/JwtServiceTests.java
@@ -30,9 +30,9 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * Unit tests for the {@link TokenService} class.
+ * Unit tests for the {@link JwtService} class.
  *
- * <p>This test class verifies the functionality of the {@code TokenService} methods for generating,
+ * <p>This test class verifies the functionality of the {@code JwtService} methods for generating,
  * decoding, and validating JWT tokens. It ensures that the JWTs generated have valid claims,
  * expected roles, and correct expiration times. The tests also check the configuration of
  * {@link JwtAuthenticationConverter} for appropriate role prefixing.
@@ -48,22 +48,22 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
-class TokenServiceTests {
+class JwtServiceTests {
 
-  @InjectMocks private TokenService tokenService;
+  @InjectMocks private JwtService jwtService;
 
   Authentication auth;
   String username;
 
   /**
    * Sets up the testing environment before each test case.
-   * Initializes {@code TokenService} with mock RSA keys and configures
+   * Initializes {@code JwtService} with mock RSA keys and configures
    * {@code Authentication} with a sample username and authority.
    */
   @BeforeEach
   void setUp() {
     RsaKeyProperties keys = new RsaKeyProperties();
-    tokenService = new TokenService(keys);
+    jwtService = new JwtService(keys);
 
     username = "testUser";
     Collection<? extends GrantedAuthority> authorities =
@@ -78,7 +78,7 @@ class TokenServiceTests {
    */
   @Test
   void givenValidKeysWhenJwtEncoderThenReturnValidJwtEncoder() {
-    JwtEncoder jwtEncoder = tokenService.jwtEncoder();
+    JwtEncoder jwtEncoder = jwtService.jwtEncoder();
 
     assertNotNull(jwtEncoder, "JwtEncoder should not be null");
     assertInstanceOf(NimbusJwtEncoder.class, jwtEncoder,
@@ -91,7 +91,7 @@ class TokenServiceTests {
    */
   @Test
   void givenValidKeysWhenJwtDecoderThenReturnValidJwtDecoder() {
-    JwtDecoder jwtDecoder = tokenService.jwtDecoder();
+    JwtDecoder jwtDecoder = jwtService.jwtDecoder();
 
     assertNotNull(jwtDecoder, "JwtDecoder should not be null");
     assertInstanceOf(NimbusJwtDecoder.class, jwtDecoder,
@@ -105,10 +105,10 @@ class TokenServiceTests {
    */
   @Test
   void givenValidAuthenticationWhenGenerateAccessTokenThenReturnAccessTokenString() {
-    String token = tokenService.generateAccessToken(auth);
+    String token = jwtService.generateAccessToken(auth);
     assertNotNull(token, "Access token should not be null");
 
-    Map<String, Object> claims = tokenService.decodeJwt(token);
+    Map<String, Object> claims = jwtService.decodeJwt(token);
     assertEquals(username, claims.get("sub"), "Subject claim should match the username");
     assertEquals("self", claims.get("iss"), "Issuer claim should be 'self'");
     assertEquals("USER", claims.get("roles"), "Roles claim should match 'USER'");
@@ -132,10 +132,10 @@ class TokenServiceTests {
    */
   @Test
   void givenValidAuthenticationWhenGenerateRefreshTokenThenReturnRefreshTokenString() {
-    String token = tokenService.generateRefreshToken(auth);
+    String token = jwtService.generateRefreshToken(auth);
     assertNotNull(token, "Refresh token should not be null");
 
-    Map<String, Object> claims = tokenService.decodeJwt(token);
+    Map<String, Object> claims = jwtService.decodeJwt(token);
     assertEquals(username, claims.get("sub"), "Subject claim should match the username");
     assertEquals("self", claims.get("iss"), "Issuer claim should be 'self'");
 
@@ -153,10 +153,10 @@ class TokenServiceTests {
    */
   @Test
   void givenValidAuthenticationWhenGenerateTokensThenReturnMapOfStringTokens() {
-    Map<String, String> tokens = tokenService.generateTokens(auth);
+    Map<String, String> tokens = jwtService.generateTokens(auth);
     assertNotNull(tokens, "Token map should not be null");
 
-    Map<String, Object> accessTokenClaims = tokenService.decodeJwt(tokens.get("accessToken"));
+    Map<String, Object> accessTokenClaims = jwtService.decodeJwt(tokens.get("accessToken"));
     assertNotNull(accessTokenClaims, "Access token claims should not be null");
     assertEquals(username, accessTokenClaims.get("sub"), "Subject claim should match the username");
     assertEquals("self", accessTokenClaims.get("iss"), "Issuer claim should be 'self'");
@@ -169,7 +169,7 @@ class TokenServiceTests {
     assertTrue(expiresAt.isBefore(expirationTime) && expiresAt.isAfter(now),
         "Token expiration time should be within 15 minutes from now");
 
-    Map<String, Object> refreshTokenClaims = tokenService.decodeJwt(tokens.get("refreshToken"));
+    Map<String, Object> refreshTokenClaims = jwtService.decodeJwt(tokens.get("refreshToken"));
     assertNotNull(refreshTokenClaims, "Refresh token claims should not be null");
 
     assertEquals(username, refreshTokenClaims.get("sub"),
@@ -193,7 +193,7 @@ class TokenServiceTests {
    */
   @Test
   void givenValidJwtTokenWhenDecodeJwtThenReturnMapOfClaims() {
-    String token = tokenService.generateAccessToken(auth);
+    String token = jwtService.generateAccessToken(auth);
     Instant now = Instant.now();
     Map<String, Object> claimsMap = Map.of(
         "sub", username,
@@ -203,7 +203,7 @@ class TokenServiceTests {
         "exp", now.plus(1, ChronoUnit.HOURS)
     );
 
-    Map<String, Object> result = tokenService.decodeJwt(token);
+    Map<String, Object> result = jwtService.decodeJwt(token);
 
     assertNotNull(result, "Decoded claims should not be null");
     assertEquals(claimsMap.get("sub"), result.get("sub"),
@@ -231,7 +231,7 @@ class TokenServiceTests {
   @Test
   void givenJwtAuthenticationConverterBeanWhenJwtAuthenticationConverterThenVerifyConfiguration() {
     JwtAuthenticationConverter jwtAuthenticationConverter =
-        tokenService.jwtAuthenticationConverter();
+        jwtService.jwtAuthenticationConverter();
     assertNotNull(jwtAuthenticationConverter);
 
     Jwt jwt = new Jwt(

--- a/src/test/java/io/github/ajmiller611/usermanagement/service/AuthenticationServiceTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/service/AuthenticationServiceTests.java
@@ -12,7 +12,7 @@ import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
 import io.github.ajmiller611.usermanagement.model.Role;
 import io.github.ajmiller611.usermanagement.model.User;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
-import io.github.ajmiller611.usermanagement.security.TokenService;
+import io.github.ajmiller611.usermanagement.security.JwtService;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -60,7 +60,7 @@ class AuthenticationServiceTests {
   @Mock private AuthenticationManager authenticationManager;
   @Mock private UserService userService;
   @Mock private UserRepository userRepository;
-  @Mock private TokenService tokenService;
+  @Mock private JwtService jwtService;
 
   LocalDateTime fixedTimestamp = LocalDateTime.of(2024, 11, 17, 0, 0, 0, 0);
   Clock fixedClock =
@@ -121,7 +121,7 @@ class AuthenticationServiceTests {
   @Test
   void givenValidCredentialsWhenLoginUserThenReturnAuthTokensDto() {
     when(authenticationManager.authenticate(any(Authentication.class))).thenReturn(auth);
-    when(tokenService.generateTokens(auth)).thenReturn(tokens);
+    when(jwtService.generateTokens(auth)).thenReturn(tokens);
     when(userRepository.findByUsername("validUser"))
         .thenReturn(Optional.of(user));
     when(userService.mapToUserDto(user)).thenReturn(userDto);

--- a/src/test/java/io/github/ajmiller611/usermanagement/service/AuthenticationServiceTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/service/AuthenticationServiceTests.java
@@ -2,13 +2,21 @@ package io.github.ajmiller611.usermanagement.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.ajmiller611.usermanagement.dto.AuthTokensDto;
+import io.github.ajmiller611.usermanagement.dto.RegistrationRequestDto;
 import io.github.ajmiller611.usermanagement.dto.UserDto;
 import io.github.ajmiller611.usermanagement.dto.UserRequestDto;
+import io.github.ajmiller611.usermanagement.exception.InvitationNotFoundException;
+import io.github.ajmiller611.usermanagement.model.Invitation;
 import io.github.ajmiller611.usermanagement.model.Role;
 import io.github.ajmiller611.usermanagement.model.User;
 import io.github.ajmiller611.usermanagement.repository.UserRepository;
@@ -60,6 +68,7 @@ class AuthenticationServiceTests {
   @Mock private AuthenticationManager authenticationManager;
   @Mock private UserService userService;
   @Mock private UserRepository userRepository;
+  @Mock private InvitationService invitationService;
   @Mock private JwtService jwtService;
 
   LocalDateTime fixedTimestamp = LocalDateTime.of(2024, 11, 17, 0, 0, 0, 0);
@@ -198,5 +207,84 @@ class AuthenticationServiceTests {
 
     assertNull(result.getUserDto(),
         "The user DTO should be null when the user does not exist in the database.");
+  }
+
+  /**
+   * Verifies a valid request dto creates a user and returns a {@link UserDto} with the
+   * created user's details.
+   */
+  @Test
+  void givenValidRequestDtoWhenCompleteRegistrationThenReturnUserDto() {
+    Role role  = new Role("USER");
+    LocalDateTime createdAtTimestamp = LocalDateTime.of(2026, 5, 1, 0, 0, 0, 0);
+    LocalDateTime expiresAtTimestamp = LocalDateTime.of(2026, 5, 8, 0, 0, 0, 0);
+    Invitation invitation = new Invitation(
+        1L,
+        "test@email.com",
+        "token",
+        role,
+        createdAtTimestamp,
+        expiresAtTimestamp,
+        false
+    );
+
+    RegistrationRequestDto registrationRequestDto = new RegistrationRequestDto(
+        invitation.getToken(),
+        "testUser",
+        "password"
+    );
+
+    UserRequestDto userRequestDto = new UserRequestDto(
+        registrationRequestDto.getUsername(),
+        registrationRequestDto.getPassword(),
+        invitation.getEmail()
+    );
+
+    userDto = new UserDto(
+        2L,
+        userRequestDto.getEmail(),
+        userRequestDto.getEmail(),
+        fixedTimestamp,
+        Set.of(role)
+    );
+
+    when(invitationService.getValidInvitation(any(String.class))).thenReturn(invitation);
+    when(userService.createAndSaveUser(any(UserRequestDto.class))).thenReturn(this.userDto);
+
+    UserDto result = authenticationService.completeRegistration(registrationRequestDto);
+
+    assertNotNull(result, "UserDto should not be null");
+    assertEquals(userDto.getUserId(), result.getUserId(),
+        "UserDto's id should be the same");
+    assertEquals(userDto.getUsername(), result.getUsername(),
+        "UserDto's username should be the same");
+    assertEquals(userDto.getEmail(), result.getEmail(),
+        "UserDto's email should be the same");
+    assertEquals(userDto.getCreatedAt(), result.getCreatedAt(),
+        "UserDto's createdAt should be the same");
+    assertEquals(userDto.getAuthorities(), result.getAuthorities(),
+        "UserDto's authorities should be the same");
+
+    verify(invitationService, times(1)).getValidInvitation(invitation.getToken());
+    verify(userService, times(1)).createAndSaveUser(any(UserRequestDto.class));
+    verify(invitationService, times(1)).markInvitationAsUsed(invitation);
+  }
+
+  /** Verifies invitation validation exceptions are propagated and registration is aborted. */
+  @Test
+  void givenNonExistingInvitationWhenCompleteRegistrationThenReturnException() {
+    RegistrationRequestDto registrationRequestDto = new RegistrationRequestDto(
+        "nonExistingToken",
+        "testUser",
+        "password"
+    );
+    when(invitationService.getValidInvitation(any(String.class)))
+        .thenThrow(new InvitationNotFoundException("Invitation not found"));
+
+    assertThrows(InvitationNotFoundException.class,
+        () -> authenticationService.completeRegistration(registrationRequestDto));
+
+    verify(userService, never()).createAndSaveUser(any(UserRequestDto.class));
+    verify(invitationService, never()).markInvitationAsUsed(any(Invitation.class));
   }
 }

--- a/src/test/java/io/github/ajmiller611/usermanagement/service/InvitationServiceTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/service/InvitationServiceTests.java
@@ -188,11 +188,30 @@ class InvitationServiceTests {
     InvitationValidationResponseDto responseDto =
         invitationService.validateInvitation(expectedToken);
 
-    verify(invitationRepository, times(1)).findByToken(expectedToken);
     assertNotNull(responseDto, "Response should not be null");
     assertEquals(expectedEmail, responseDto.getEmail(), "Email should be set");
     assertEquals(expectedRole.getAuthority(), responseDto.getRole(), "Role should be set");
     assertEquals(expectedExpiredAt, responseDto.getExpiresAt(), "Expired at should be set");
+  }
+
+  /** Verifies a valid token returns the associated invitation. */
+  @Test
+  void givenValidTokenWhenGetValidInvitationThenReturnInvitation() {
+    when(clock.instant()).thenReturn(fixedClock.instant());
+    when(clock.getZone()).thenReturn(fixedClock.getZone());
+    when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.of(invitation));
+
+    Invitation result =
+        invitationService.getValidInvitation(expectedToken);
+
+    verify(invitationRepository, times(1)).findByToken(expectedToken);
+    assertNotNull(result, "Response should not be null");
+    assertEquals(expectedEmail, result.getEmail(), "Email should be set");
+    assertEquals(expectedToken, result.getToken(), "Token should be set");
+    assertEquals(expectedRole, result.getRole(), "Role should be set");
+    assertEquals(expectedCreatedAt, result.getCreatedAt(), "Created at should be set");
+    assertEquals(expectedExpiredAt, result.getExpiresAt(), "Expired at should be set");
+    assertFalse(result.isUsed(), "Marked should be false");
   }
 
   /**
@@ -200,12 +219,12 @@ class InvitationServiceTests {
    * that is not associated with an existing {@link Invitation}.
    */
   @Test
-  void givenInvalidInvitationWhenValidateInvitationThenThrowInvitationNotFoundException() {
+  void givenNonExistentInvitationWhenGetValidInvitationThenThrowInvitationNotFoundException() {
     when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.empty());
 
     assertThrows(InvitationNotFoundException.class,
-        () -> invitationService.validateInvitation(expectedToken),
-        "Expected validateInvitation to throw an exception when invitation is not found");
+        () -> invitationService.getValidInvitation(expectedToken),
+        "Expected getValidInvitation to throw an exception when invitation is not found");
   }
 
   /**
@@ -213,7 +232,7 @@ class InvitationServiceTests {
    * an expired {@link Invitation}.
    */
   @Test
-  void givenExpiredInvitationWhenValidateInvitationThenThrowInvitationExpiredException() {
+  void givenExpiredInvitationWhenGetValidInvitationThenThrowInvitationExpiredException() {
     invitation = new Invitation(
         1L,
         invitationRequestDto.getEmail(),
@@ -228,8 +247,8 @@ class InvitationServiceTests {
     when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.of(invitation));
 
     assertThrows(InvitationExpiredException.class,
-        () -> invitationService.validateInvitation(expectedToken),
-        "Expected validateInvitation to throw an exception when invitation is expired");
+        () -> invitationService.getValidInvitation(expectedToken),
+        "Expected getValidInvitation to throw an exception when invitation is expired");
   }
 
   /**
@@ -237,7 +256,7 @@ class InvitationServiceTests {
    * an {@link Invitation} that has been used already.
    */
   @Test
-  void givenAlreadyUsedInvitationWhenValidateInvitationThenThrowInvitationAlreadyUsedException() {
+  void givenAlreadyUsedInvitationWhenGetValidInvitationThenThrowInvitationAlreadyUsedException() {
     invitation = new Invitation(
         1L,
         invitationRequestDto.getEmail(),
@@ -247,13 +266,11 @@ class InvitationServiceTests {
         fixedTimestamp.plusDays(7),
         true
     );
-    when(clock.instant()).thenReturn(fixedClock.instant());
-    when(clock.getZone()).thenReturn(fixedClock.getZone());
     when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.of(invitation));
 
     assertThrows(InvitationAlreadyUsedException.class,
-        () -> invitationService.validateInvitation(expectedToken),
-        "Expected validateInvitation to throw an exception when invitation is already used");
+        () -> invitationService.getValidInvitation(expectedToken),
+        "Expected getValidInvitation to throw an exception when invitation is already used");
   }
 
   /** Verify an {@link Invitation} is updated and marked as used. */

--- a/src/test/java/io/github/ajmiller611/usermanagement/service/InvitationServiceTests.java
+++ b/src/test/java/io/github/ajmiller611/usermanagement/service/InvitationServiceTests.java
@@ -1,0 +1,271 @@
+package io.github.ajmiller611.usermanagement.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.ajmiller611.usermanagement.dto.InvitationRequestDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationResponseDto;
+import io.github.ajmiller611.usermanagement.dto.InvitationValidationResponseDto;
+import io.github.ajmiller611.usermanagement.exception.InvitationAlreadyUsedException;
+import io.github.ajmiller611.usermanagement.exception.InvitationExpiredException;
+import io.github.ajmiller611.usermanagement.exception.InvitationNotFoundException;
+import io.github.ajmiller611.usermanagement.exception.RoleNotFoundException;
+import io.github.ajmiller611.usermanagement.model.Invitation;
+import io.github.ajmiller611.usermanagement.model.Role;
+import io.github.ajmiller611.usermanagement.repository.InvitationRepository;
+import io.github.ajmiller611.usermanagement.repository.RoleRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Unit tests for the {@link InvitationService} class.
+ *
+ * <p>This test class focuses on verifying the core functionality of the {@link InvitationService},
+ * including invitation creation, token validation, and marking an invitation as used.</p>
+ *
+ * <h2>Key Features Tested</h2>
+ * <ul>
+ *   <li>
+ *     <strong>Invitation Creation:</strong> Ensures that a valid {@link InvitationRequestDto}
+ *     results in an {@link Invitation} entity being correctly constructed,
+ *     passed to the repository, and mapped to an {@link InvitationResponseDto}.
+ *   </li>
+ *   <li>
+ *     <strong>Invitation Validation:</strong> Ensures that an invitation token is validated
+ *     against existence, expiration, and usage status, and that appropriate exceptions are thrown
+ *     for invalid cases.
+ *   </li>
+ *   <li>
+ *     <strong>Mark Invitation as Used:</strong> Ensures an {@link Invitation}'s used flag
+ *     is updated and persisted via the repository.
+ *   </li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class InvitationServiceTests {
+
+  @InjectMocks private InvitationService invitationService;
+  @Mock private InvitationRepository invitationRepository;
+  @Mock private InvitationTokenService invitationTokenService;
+  @Mock private RoleRepository roleRepository;
+  @Mock private Clock clock;
+
+  LocalDateTime fixedTimestamp = LocalDateTime.of(2026, 5, 29, 0, 0, 0, 0);
+  Clock fixedClock =
+      Clock.fixed(
+          fixedTimestamp.atZone(ZoneId.systemDefault()).toInstant(),
+          ZoneId.systemDefault());
+
+  InvitationRequestDto invitationRequestDto;
+  Invitation invitation;
+  Role role;
+
+  String expectedEmail;
+  String expectedToken;
+  Role expectedRole;
+  LocalDateTime expectedCreatedAt;
+  LocalDateTime expectedExpiredAt;
+
+  @BeforeEach
+  void setUp() {
+    role = new Role("USER");
+
+    invitationRequestDto = new InvitationRequestDto(
+        "test@email.com",
+        "USER"
+    );
+
+    expectedEmail = invitationRequestDto.getEmail();
+    expectedToken = "token";
+    expectedRole = role;
+    expectedCreatedAt = fixedTimestamp;
+    expectedExpiredAt = expectedCreatedAt.plusDays(7);
+
+    invitation = new Invitation(
+        1L,
+        invitationRequestDto.getEmail(),
+        "token",
+        role,
+        fixedTimestamp,
+        fixedTimestamp.plusDays(7),
+        false
+    );
+  }
+
+  /**
+   * Verifies a valid request creates the invitation entity and saves it to the database.
+   * Also, checks that the response includes the correct information.
+   */
+  @Test
+  void givenValidRequestWhenCreateInvitationThenReturnInvitationResponseDto() {
+    when(clock.instant()).thenReturn(fixedClock.instant());
+    when(clock.getZone()).thenReturn(fixedClock.getZone());
+    when(roleRepository.findByAuthority(invitationRequestDto.getRole()))
+        .thenReturn(Optional.of(role));
+    when(invitationTokenService.generateInvitationToken()).thenReturn("token");
+    when(invitationRepository.save(any(Invitation.class))).thenReturn(invitation);
+
+    ArgumentCaptor<Invitation> captor = ArgumentCaptor.forClass(Invitation.class);
+
+    try (LogCaptor logCaptor = LogCaptor.forClass(InvitationService.class)) {
+      final InvitationResponseDto responseDto =
+          invitationService.createInvitation(invitationRequestDto);
+
+      verify(roleRepository).findByAuthority("USER");
+      verify(invitationTokenService).generateInvitationToken();
+      verify(invitationRepository, times(1)).save(captor.capture());
+
+      Invitation saved = captor.getValue();
+
+      assertNotNull(responseDto, "Response should not be null");
+      assertEquals(expectedEmail, saved.getEmail(), "Email should be set");
+      assertEquals(expectedToken, saved.getToken(), "Token should be set");
+      assertEquals(expectedRole, saved.getRole(), "Role should be set");
+      assertEquals(expectedCreatedAt, saved.getCreatedAt(), "Created at should be set");
+      assertEquals(expectedExpiredAt, saved.getExpiresAt(), "Expires at should be set");
+      assertFalse(saved.isUsed(), "Marked should be false");
+
+      assertEquals(expectedToken, responseDto.getToken(), "Response should have the token");
+      assertEquals(expectedEmail, responseDto.getEmail(), "Response should have the email");
+      assertEquals(
+          expectedExpiredAt,
+          responseDto.getExpiresAt(),
+          "Response should have the expires at"
+      );
+
+      assertThat(logCaptor.getInfoLogs())
+          .withFailMessage("Expected log message for create invitation request with DTO details")
+          .anyMatch(log ->
+              log.contains("Create invitation request with DTO: " + invitationRequestDto.toString())
+          );
+
+      assertThat(logCaptor.getInfoLogs())
+          .withFailMessage("Expected log message for after invitation creation with ID")
+          .anyMatch(
+              log -> log.contains("Invitation created with ID: ")
+          );
+    }
+  }
+
+  /** Verifies a {@link RoleNotFoundException} is thrown when the {@link Role} does not exist. */
+  @Test
+  void givenInvalidRoleWhenCreateInvitationThenThrowRoleNotFoundException() {
+    when(roleRepository.findByAuthority(invitationRequestDto.getRole()))
+        .thenReturn(Optional.empty());
+
+    assertThrows(RoleNotFoundException.class,
+        () -> invitationService.createInvitation(invitationRequestDto),
+        "Expected createInvitation to throw an exception when role is not found");
+  }
+
+  /** Verifies a valid token responds with the needed details in the response dto. */
+  @Test
+  void givenValidTokenWhenValidateInvitationThenReturnValidationResponseDto() {
+    when(clock.instant()).thenReturn(fixedClock.instant());
+    when(clock.getZone()).thenReturn(fixedClock.getZone());
+    when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.of(invitation));
+
+    InvitationValidationResponseDto responseDto =
+        invitationService.validateInvitation(expectedToken);
+
+    verify(invitationRepository, times(1)).findByToken(expectedToken);
+    assertNotNull(responseDto, "Response should not be null");
+    assertEquals(expectedEmail, responseDto.getEmail(), "Email should be set");
+    assertEquals(expectedRole.getAuthority(), responseDto.getRole(), "Role should be set");
+    assertEquals(expectedExpiredAt, responseDto.getExpiresAt(), "Expired at should be set");
+  }
+
+  /**
+   * Verifies a {@link InvitationNotFoundException} is thrown when validating a token
+   * that is not associated with an existing {@link Invitation}.
+   */
+  @Test
+  void givenInvalidInvitationWhenValidateInvitationThenThrowInvitationNotFoundException() {
+    when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.empty());
+
+    assertThrows(InvitationNotFoundException.class,
+        () -> invitationService.validateInvitation(expectedToken),
+        "Expected validateInvitation to throw an exception when invitation is not found");
+  }
+
+  /**
+   * Verifies a {@link InvitationExpiredException} is thrown when validating
+   * an expired {@link Invitation}.
+   */
+  @Test
+  void givenExpiredInvitationWhenValidateInvitationThenThrowInvitationExpiredException() {
+    invitation = new Invitation(
+        1L,
+        invitationRequestDto.getEmail(),
+        "token",
+        role,
+        fixedTimestamp,
+        fixedTimestamp.minusDays(1),
+        false
+    );
+    when(clock.instant()).thenReturn(fixedClock.instant());
+    when(clock.getZone()).thenReturn(fixedClock.getZone());
+    when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.of(invitation));
+
+    assertThrows(InvitationExpiredException.class,
+        () -> invitationService.validateInvitation(expectedToken),
+        "Expected validateInvitation to throw an exception when invitation is expired");
+  }
+
+  /**
+   * Verifies a {@link InvitationAlreadyUsedException} is thrown when validating
+   * an {@link Invitation} that has been used already.
+   */
+  @Test
+  void givenAlreadyUsedInvitationWhenValidateInvitationThenThrowInvitationAlreadyUsedException() {
+    invitation = new Invitation(
+        1L,
+        invitationRequestDto.getEmail(),
+        "token",
+        role,
+        fixedTimestamp,
+        fixedTimestamp.plusDays(7),
+        true
+    );
+    when(clock.instant()).thenReturn(fixedClock.instant());
+    when(clock.getZone()).thenReturn(fixedClock.getZone());
+    when(invitationRepository.findByToken(expectedToken)).thenReturn(Optional.of(invitation));
+
+    assertThrows(InvitationAlreadyUsedException.class,
+        () -> invitationService.validateInvitation(expectedToken),
+        "Expected validateInvitation to throw an exception when invitation is already used");
+  }
+
+  /** Verify an {@link Invitation} is updated and marked as used. */
+  @Test
+  void givenInvitationWhenMarkInvitationAsUsedThenUpdateInvitationAsUsed() {
+    ArgumentCaptor<Invitation> captor = ArgumentCaptor.forClass(Invitation.class);
+    invitationService.markInvitationAsUsed(invitation);
+
+    verify(invitationRepository, times(1)).save(captor.capture());
+
+    Invitation saved = captor.getValue();
+
+    assertTrue(saved.isUsed());
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces an invitation-based registration flow that allows new users to complete account creation using a valid invitation token.

## Changes

- Added `/auth/register/invitation` endpoint to handle registration completion requests
- Implemented invitation validation rules:
  - token must exist
  - token must not be expired
  - token must not have already been used
- On successful validation:
  - a new user is created using the invitation email and provided credentials
  - the invitation is marked as used to prevent reuse
- Registration logic is handled in the authentication service layer to separate controller and business concerns
- Returns created user details (excluding sensitive fields such as password)